### PR TITLE
Macro args declarations

### DIFF
--- a/right/src/macros/commands.c
+++ b/right/src/macros/commands.c
@@ -1373,6 +1373,8 @@ conditionPassed:
 
 uint8_t Macros_TryConsumeKeyId(parser_context_t* ctx)
 {
+    // TODO: allow $macroArg.xxx for type keyId here as well
+
     uint8_t keyId = MacroKeyIdParser_TryConsumeKeyId(ctx);
 
     if (keyId == 255 && isNUM(ctx)) {

--- a/right/src/macros/commands.c
+++ b/right/src/macros/commands.c
@@ -1012,7 +1012,7 @@ static macro_result_t processMacroArgCommand(parser_context_t* ctx)
     macro_argument_alloc_result_t res = Macros_AllocateMacroArgument(MACRO_STATE_SLOT(S), idStart, idEnd, argType, argNumber+1);
     switch (res) {
     case MacroArgAllocResult_Success:
-        // macro arggument successfully allocated
+        // macro argument successfully allocated
         break;
     case MacroArgAllocResult_PoolLimitExceeded:
         Macros_ReportErrorPos(ctx, "Too many arguments across simultaneously active macros (argument pool exhausted)");

--- a/right/src/macros/commands.c
+++ b/right/src/macros/commands.c
@@ -1001,7 +1001,12 @@ static macro_result_t processMacroArgCommand(parser_context_t* ctx)
         argType = MacroArgType_Any;
     }
 
-    // allocate an argument slot if there is room
+    // The following two blocks (counting arguments, then allocating argument) 
+    // could be optimised to walk the macro arg pool only once.
+    // The current implementation is straightforward to read, and the slight performance
+    // decrease at the start of a macro (when macroArg commands are processed) seems negligible.
+
+    // check whether we are exceeding the arguments for this macro
     uint8_t argNumber = Macros_CountMacroArgumentsByOwner(MACRO_STATE_SLOT(S));
     if (argNumber >= MAX_MACRO_ARGUMENT_COUNT) {
         Macros_ReportErrorPos(ctx, "Maximum number of macro arguments exceeded");

--- a/right/src/macros/commands.c
+++ b/right/src/macros/commands.c
@@ -1027,9 +1027,9 @@ static macro_result_t processMacroArgCommand(parser_context_t* ctx)
         return MacroResult_Header;
     }
 
-    // rest of command is descriptive label, ignore. TODO: Should be parsed as string literal.
+    // rest of command is descriptive label, ignore. TODO: Should be parsed as string token.
     //while (Macros_ConsumeCharOfString(ctx, &stringOffset, &textIndex, &textSubIndex) != '\0') {};
-    (void) consumeStringLiteral(ctx);
+    Macros_ConsumeStringToken(ctx);
 
     return MacroResult_Header;
 }

--- a/right/src/macros/commands.c
+++ b/right/src/macros/commands.c
@@ -943,10 +943,6 @@ static macro_result_t processPlayMacroCommand(parser_context_t* ctx)
 
 static macro_result_t processMacroArgCommand(parser_context_t* ctx)
 {
-    uint16_t stringOffset = 0;
-    uint16_t textIndex = 0;
-    uint16_t textSubIndex = 0;
-
     if (S->ms.macroHeadersProcessed) {
         Macros_ReportErrorPos(ctx, "macroArg commands must be placed before any other commands in the macro");
         return MacroResult_Finished;
@@ -978,10 +974,12 @@ static macro_result_t processMacroArgCommand(parser_context_t* ctx)
         else if (ConsumeToken(ctx, "string")) {
             argType = MacroArgType_String;
         }
-        else if (ConsumeToken(ctx, "keyid")) {
+        else if (ConsumeToken(ctx, "keyid") || ConsumeToken(ctx, "keyId")) {
             argType = MacroArgType_KeyId;
         }
-        else if (ConsumeToken(ctx, "scancode")) {
+        else if (ConsumeToken(ctx, "scancode") || ConsumeToken(ctx, "scanCode") || 
+                 ConsumeToken(ctx, "moddedScanCode") || ConsumeToken(ctx, "moddedScancode") || 
+                 ConsumeToken(ctx, "shortcut")) {
             argType = MacroArgType_ScanCode;
         }
         else if (ConsumeToken(ctx, "any")) {
@@ -1027,8 +1025,7 @@ static macro_result_t processMacroArgCommand(parser_context_t* ctx)
         return MacroResult_Header;
     }
 
-    // rest of command is descriptive label, ignore. TODO: Should be parsed as string token.
-    //while (Macros_ConsumeCharOfString(ctx, &stringOffset, &textIndex, &textSubIndex) != '\0') {};
+    // rest of command is descriptive label, ignore.
     Macros_ConsumeStringToken(ctx);
 
     return MacroResult_Header;

--- a/right/src/macros/commands.c
+++ b/right/src/macros/commands.c
@@ -1370,7 +1370,8 @@ conditionPassed:
 
 uint8_t Macros_TryConsumeKeyId(parser_context_t* ctx)
 {
-    // TODO: allow $macroArg.xxx for type keyId here as well
+    // TODO: allow $macroArg.xxx for type keyId here as well.
+    // - this should already work via Macros_ConsumeInt() -> consumeValue() chain.
 
     uint8_t keyId = MacroKeyIdParser_TryConsumeKeyId(ctx);
 

--- a/right/src/macros/commands.c
+++ b/right/src/macros/commands.c
@@ -1028,7 +1028,8 @@ static macro_result_t processMacroArgCommand(parser_context_t* ctx)
     }
 
     // rest of command is descriptive label, ignore. TODO: Should be parsed as string literal.
-    while (Macros_ConsumeCharOfString(ctx, &stringOffset, &textIndex, &textSubIndex) != '\0') {};
+    //while (Macros_ConsumeCharOfString(ctx, &stringOffset, &textIndex, &textSubIndex) != '\0') {};
+    (void) consumeStringLiteral(ctx);
 
     return MacroResult_Header;
 }

--- a/right/src/macros/commands.c
+++ b/right/src/macros/commands.c
@@ -2486,7 +2486,7 @@ static macro_result_t processCommand(parser_context_t* ctx)
     if (cmdTokEnd > ctx->at && cmdTokEnd[-1] == ':') {
         //skip labels
         ConsumeAnyToken(ctx);
-        if (ctx->at == ctx->end && IsEnd(ctx)) {
+        if (/* ctx->at >= ctx->end && */ IsEnd(ctx)) {
             return MacroResult_Finished;
         }
     }

--- a/right/src/macros/core.h
+++ b/right/src/macros/core.h
@@ -176,7 +176,7 @@
             // ---- 4-aligned ----
             macro_usb_keyboard_reports_t reports;
 
-            uint8_t argumentCount : 4; // TODO: we don't need this; we can calculate it using Macros_CountMacroArgumentsByOwner()
+            //uint8_t argumentCount : 4; // TODO: we don't need this; we can calculate it using Macros_CountMacroArgumentsByOwner()
             bool macroHeadersProcessed : 1;
         } ms;
 

--- a/right/src/macros/display.c
+++ b/right/src/macros/display.c
@@ -46,7 +46,7 @@ static uint8_t consumeDisplayString(parser_context_t* ctx, char* str, uint8_t le
     } else if (ctx->at != ctx->end) {
         string_reader_context_t stringCtx;
 
-        StrRead_InitContext(ctx, &stringCtx, StrReadMode_Verbatim);
+        StrRead_InitContext(ctx, &stringCtx, StrReadMode_Literal);
 
         for (uint8_t i = 0; true; i++) {
             char c = StrRead_ConsumeCharOfString(ctx, &stringCtx);

--- a/right/src/macros/display.c
+++ b/right/src/macros/display.c
@@ -37,6 +37,10 @@ static uint8_t consumeDisplayString(parser_context_t* ctx, char* str, uint8_t le
     if (Macros_IsNUM(ctx)) {
 #ifndef __ZEPHYR__
         macro_variable_t value = Macros_ConsumeAnyValue(ctx);
+        if (value.type == MacroVariableType_None) {
+            Macros_ReportErrorTok(ctx, "Value expected but found:");
+            return 0;
+        }
         SegmentDisplay_SerializeVar(str, value);
         textLen = 3;
 #else

--- a/right/src/macros/display.c
+++ b/right/src/macros/display.c
@@ -48,7 +48,7 @@ static uint8_t consumeDisplayString(parser_context_t* ctx, char* str, uint8_t le
 
         StrRead_InitContext(ctx, &stringCtx, StrReadMode_Literal);
 
-        for (uint8_t i = 0; i<8 /* true */; i++) {
+        for (uint8_t i = 0; i<2 /* true */; i++) {
             char c = StrRead_ConsumeCharOfString(ctx, &stringCtx);
             if (c == '\0') {
                 break;

--- a/right/src/macros/display.c
+++ b/right/src/macros/display.c
@@ -38,7 +38,7 @@ static uint8_t consumeDisplayString(parser_context_t* ctx, char* str, uint8_t le
 #ifndef __ZEPHYR__
         macro_variable_t value = Macros_ConsumeAnyValue(ctx);
         if (value.type == MacroVariableType_None) {
-            Macros_ReportErrorTok(ctx, "Value expected but found:");
+            Macros_ReportErrorTok(ctx, "Could not resolve:");
             return 0;
         }
         SegmentDisplay_SerializeVar(str, value);

--- a/right/src/macros/display.c
+++ b/right/src/macros/display.c
@@ -44,9 +44,12 @@ static uint8_t consumeDisplayString(parser_context_t* ctx, char* str, uint8_t le
 #endif
         return textLen;
     } else if (ctx->at != ctx->end) {
-        uint16_t stringOffset = 0, textIndex = 0, textSubIndex = 0;
+        string_reader_context_t stringCtx;
+
+        StrRead_InitContext(ctx, &stringCtx, StrReadMode_Undetermined);
+
         for (uint8_t i = 0; true; i++) {
-            char c = Macros_ConsumeCharOfString(ctx, &stringOffset, &textIndex, &textSubIndex);
+            char c = StrRead_ConsumeCharOfString(ctx, &stringCtx);
             if (c == '\0') {
                 break;
             }

--- a/right/src/macros/display.c
+++ b/right/src/macros/display.c
@@ -46,7 +46,7 @@ static uint8_t consumeDisplayString(parser_context_t* ctx, char* str, uint8_t le
     } else if (ctx->at != ctx->end) {
         string_reader_context_t stringCtx;
 
-        StrRead_InitContext(ctx, &stringCtx, StrReadMode_Undetermined);
+        StrRead_InitContext(ctx, &stringCtx, StrReadMode_Literal);
 
         for (uint8_t i = 0; true; i++) {
             char c = StrRead_ConsumeCharOfString(ctx, &stringCtx);

--- a/right/src/macros/display.c
+++ b/right/src/macros/display.c
@@ -46,7 +46,7 @@ static uint8_t consumeDisplayString(parser_context_t* ctx, char* str, uint8_t le
     } else if (ctx->at != ctx->end) {
         string_reader_context_t stringCtx;
 
-        StrRead_InitContext(ctx, &stringCtx, StrReadMode_Literal);
+        StrRead_InitContext(ctx, &stringCtx, StrReadMode_Verbatim);
 
         for (uint8_t i = 0; true; i++) {
             char c = StrRead_ConsumeCharOfString(ctx, &stringCtx);

--- a/right/src/macros/display.c
+++ b/right/src/macros/display.c
@@ -48,7 +48,7 @@ static uint8_t consumeDisplayString(parser_context_t* ctx, char* str, uint8_t le
 
         StrRead_InitContext(ctx, &stringCtx, StrReadMode_Literal);
 
-        for (uint8_t i = 0; true; i++) {
+        for (uint8_t i = 0; i<8 /* true */; i++) {
             char c = StrRead_ConsumeCharOfString(ctx, &stringCtx);
             if (c == '\0') {
                 break;

--- a/right/src/macros/display.c
+++ b/right/src/macros/display.c
@@ -214,6 +214,7 @@ void processList(parser_context_t* ctx, bool show, uint16_t time) {
 
 macro_result_t Macros_ProcessSetLedTxtCommand(parser_context_t* ctx)
 {
+    // TODO: I guess ATTR_UNUSED is not correct here?
     ATTR_UNUSED int16_t time = Macros_ConsumeInt(ctx);
 
     macro_result_t res = MacroResult_Finished;

--- a/right/src/macros/display.c
+++ b/right/src/macros/display.c
@@ -48,7 +48,7 @@ static uint8_t consumeDisplayString(parser_context_t* ctx, char* str, uint8_t le
 
         StrRead_InitContext(ctx, &stringCtx, StrReadMode_Literal);
 
-        for (uint8_t i = 0; i<2 /* true */; i++) {
+        for (uint8_t i = 0; true; i++) {
             char c = StrRead_ConsumeCharOfString(ctx, &stringCtx);
             if (c == '\0') {
                 break;

--- a/right/src/macros/keyid_parser.c
+++ b/right/src/macros/keyid_parser.c
@@ -172,6 +172,7 @@ uint8_t MacroKeyIdParser_TryConsumeKeyId(parser_context_t* ctx)
     const char* end1 = IdentifierEnd(ctx);
     const lookup_record_t* record = lookup(0, lookup_size-1, ctx->at, end1);
 
+    // TODO: WHY this second attempt with dot??
     // if failed, try consume with dot
     if (record == NULL && *end1 == '.' && end1+1 < ctx->end) {
         CTX_COPY(ctx2, *ctx);

--- a/right/src/macros/scancode_commands.c
+++ b/right/src/macros/scancode_commands.c
@@ -480,6 +480,8 @@ macro_result_t Macros_ProcessTextAction(void)
 
 static macro_action_t decodeKeyAndConsume(parser_context_t* ctx, macro_sub_action_t defaultSubAction)
 {
+    // TODO: allow $macroArg.xxx for type scancode ("modded scancode") here as well
+
     macro_action_t action;
     const char* end = TokEnd(ctx->at, ctx->end);
     MacroShortcutParser_Parse(ctx->at, end, defaultSubAction, &action, NULL);

--- a/right/src/macros/scancode_commands.c
+++ b/right/src/macros/scancode_commands.c
@@ -489,6 +489,18 @@ static macro_action_t decodeKeyAndConsume(parser_context_t* ctx, macro_sub_actio
     return action;
 }
 
+void dequoteContext(parser_context_t* ctx)
+{
+    if (ctx->at < ctx->end && (*ctx->at == '\'' || *ctx->at == '"')) {
+        char limiter = *ctx->at++;         // remember starting quote and skip it
+        if (ctx->end > ctx->at && *(ctx->end - 1) == limiter) {  // check if ending quote matches starting quote
+            ctx->end--;                    // if yes, skip the ending quote as well
+        } else {
+            ctx->at--;                     // if not, step back and keep quotes
+        }
+    }
+}
+
 macro_result_t Macros_ProcessKeyCommandAndConsume(parser_context_t* ctx, macro_sub_action_t type, macro_usb_keyboard_reports_t* reports)
 {
     if (reports == NULL) {
@@ -520,9 +532,7 @@ macro_result_t Macros_ProcessKeyCommandAndConsume(parser_context_t* ctx, macro_s
             .nestingLevel = ctx->nestingLevel,
             .nestingBound = ctx->nestingBound,
         };
-        if (stringCtx.at < stringCtx.end && (*stringCtx.at == '\'' || *stringCtx.at == '"')) {
-            stringCtx.at++;
-        }
+        dequoteContext(&stringCtx); // remove enclosing quotes if they exist (hack to allow simple strings)
         action = decodeKeyAndConsume(&stringCtx, type);
         if (stringCtx.at < stringCtx.end && (*stringCtx.at == '\'' || *stringCtx.at == '"')) {
             stringCtx.at++;

--- a/right/src/macros/scancode_commands.c
+++ b/right/src/macros/scancode_commands.c
@@ -480,8 +480,6 @@ macro_result_t Macros_ProcessTextAction(void)
 
 static macro_action_t decodeKeyAndConsume(parser_context_t* ctx, macro_sub_action_t defaultSubAction)
 {
-    // TODO: allow $macroArg.xxx for type scancode ("modded scancode") here as well
-
     macro_action_t action;
     const char* end = TokEnd(ctx->at, ctx->end);
     MacroShortcutParser_Parse(ctx->at, end, defaultSubAction, &action, NULL);
@@ -500,7 +498,33 @@ macro_result_t Macros_ProcessKeyCommandAndConsume(parser_context_t* ctx, macro_s
         reports = &Macros_PersistentReports;
     }
 
-    macro_action_t action = decodeKeyAndConsume(ctx, type);
+    // TODO: allow $macroArg.xxx for type scancode ("modded scancode") here as well.
+    // - check for $
+    // - if found, call Macros_ConsumeString() to get a string segment (uses consumeValue())
+    // - Macros_ConsumeString() is new (in vars.c) and should coalesceType to string
+    // - parse that string segment as a shortcut (with MacroShortcutParser_Parse) to get the scancode and modifiers
+
+    if (*ctx->at == '$') {
+        string_segment_t segment = Macros_ConsumeString(ctx);
+        if (segment.start == NULL) {
+            Macros_ReportErrorTok("Expected shortcut string but found:");
+            return MacroResult_Finished;
+        }
+        else {
+            parser_context_t stringCtx = (parser_context_t) {
+                .begin = segment.start,
+                .at = segment.start,
+                .end = segment.end,
+                .macroState = ctx->macroState,
+                .nestingLevel = ctx->nestingLevel,
+                .nestingBound = ctx->nestingBound,
+            };
+        }
+        macro_action_t action = decodeKeyAndConsume(&stringCtx, type);
+    }
+    else {
+        macro_action_t action = decodeKeyAndConsume(ctx, type);
+    }
 
     if (Macros_DryRun) {
         return MacroResult_Finished;

--- a/right/src/macros/scancode_commands.c
+++ b/right/src/macros/scancode_commands.c
@@ -498,6 +498,8 @@ macro_result_t Macros_ProcessKeyCommandAndConsume(parser_context_t* ctx, macro_s
         reports = &Macros_PersistentReports;
     }
 
+    macro_action_t action;
+
     // TODO: allow $macroArg.xxx for type scancode ("modded scancode") here as well.
     // - check for $
     // - if found, call Macros_ConsumeString() to get a string segment (uses consumeValue())
@@ -507,23 +509,21 @@ macro_result_t Macros_ProcessKeyCommandAndConsume(parser_context_t* ctx, macro_s
     if (*ctx->at == '$') {
         string_segment_t segment = Macros_ConsumeString(ctx);
         if (segment.start == NULL) {
-            Macros_ReportErrorTok("Expected shortcut string but found:");
+            Macros_ReportErrorTok(ctx, "Expected shortcut string but found:");
             return MacroResult_Finished;
         }
-        else {
-            parser_context_t stringCtx = (parser_context_t) {
-                .begin = segment.start,
-                .at = segment.start,
-                .end = segment.end,
-                .macroState = ctx->macroState,
-                .nestingLevel = ctx->nestingLevel,
-                .nestingBound = ctx->nestingBound,
-            };
-        }
-        macro_action_t action = decodeKeyAndConsume(&stringCtx, type);
+        parser_context_t stringCtx = (parser_context_t) {
+            .begin = segment.start,
+            .at = segment.start,
+            .end = segment.end,
+            .macroState = ctx->macroState,
+            .nestingLevel = ctx->nestingLevel,
+            .nestingBound = ctx->nestingBound,
+        };
+        action = decodeKeyAndConsume(&stringCtx, type);
     }
     else {
-        macro_action_t action = decodeKeyAndConsume(ctx, type);
+        action = decodeKeyAndConsume(ctx, type);
     }
 
     if (Macros_DryRun) {

--- a/right/src/macros/scancode_commands.c
+++ b/right/src/macros/scancode_commands.c
@@ -520,7 +520,13 @@ macro_result_t Macros_ProcessKeyCommandAndConsume(parser_context_t* ctx, macro_s
             .nestingLevel = ctx->nestingLevel,
             .nestingBound = ctx->nestingBound,
         };
+        if (stringCtx.at < stringCtx.end && (*stringCtx.at == '\'' || *stringCtx.at == '"')) {
+            stringCtx.at++;
+        }
         action = decodeKeyAndConsume(&stringCtx, type);
+        if (stringCtx.at < stringCtx.end && (*stringCtx.at == '\'' || *stringCtx.at == '"')) {
+            stringCtx.at++;
+        }
     }
     else {
         action = decodeKeyAndConsume(ctx, type);

--- a/right/src/macros/scancode_commands.c
+++ b/right/src/macros/scancode_commands.c
@@ -534,6 +534,7 @@ macro_result_t Macros_ProcessKeyCommandAndConsume(parser_context_t* ctx, macro_s
         };
         dequoteContext(&stringCtx); // remove enclosing quotes if they exist (hack to allow simple strings)
         action = decodeKeyAndConsume(&stringCtx, type);
+        // the next part should not be necessary, because dequoteContext should have already removed the quotes.
         if (stringCtx.at < stringCtx.end && (*stringCtx.at == '\'' || *stringCtx.at == '"')) {
             stringCtx.at++;
         }

--- a/right/src/macros/scancode_commands.c
+++ b/right/src/macros/scancode_commands.c
@@ -512,7 +512,7 @@ macro_result_t Macros_ProcessKeyCommandAndConsume(parser_context_t* ctx, macro_s
 
     macro_action_t action;
 
-    // TODO: allow $macroArg.xxx for type scancode ("modded scancode") here as well.
+    // Allow $macroArg.xxx for type scancode ("modded scancode") here as well.
     // - check for $
     // - if found, call Macros_ConsumeString() to get a string segment (uses consumeValue())
     // - Macros_ConsumeString() is new (in vars.c) and should coalesceType to string

--- a/right/src/macros/set_command.c
+++ b/right/src/macros/set_command.c
@@ -266,14 +266,14 @@ static macro_variable_t module(parser_context_t* ctx, set_command_action_t actio
     module_id_t moduleId = ConsumeModuleId(ctx);
     module_configuration_t* module = GetModuleConfiguration(moduleId);
 
-    ConsumeUntilDot(ctx);
+    ConsumeOneDot(ctx);
 
     if (Macros_ParserError) {
         return noneVar();
     }
 
     if (ConsumeToken(ctx, "navigationMode")) {
-        ConsumeUntilDot(ctx);
+        ConsumeOneDot(ctx);
         return moduleNavigationMode(ctx, action, module);
     }
     else if (ConsumeToken(ctx, "holdContinuationTimeout") && moduleId == ModuleId_TouchpadRight) {
@@ -348,7 +348,7 @@ static macro_variable_t secondaryRoles(parser_context_t* ctx, set_command_action
         ASSIGN_CUSTOM(int32_t, intVar, Cfg.SecondaryRoles_Strategy, ConsumeSecondaryRoleStrategy(ctx));
     }
     else if (ConsumeToken(ctx, "advanced")) {
-        ConsumeUntilDot(ctx);
+        ConsumeOneDot(ctx);
         return secondaryRoleAdvanced(ctx, action);
     }
     else {
@@ -414,7 +414,7 @@ static macro_variable_t mouseKeys(parser_context_t* ctx, set_command_action_t ac
         return noneVar();
     }
 
-    ConsumeUntilDot(ctx);
+    ConsumeOneDot(ctx);
 
     if (ConsumeToken(ctx, "initialSpeed")) {
         DEFINE_INT_LIMITS(0, 255);
@@ -540,7 +540,7 @@ static macro_variable_t keyRgb(parser_context_t* ctx, set_command_action_t actio
 {
     layer_id_t layerId = Macros_ConsumeLayerId(ctx);
 
-    ConsumeUntilDot(ctx);
+    ConsumeOneDot(ctx);
 
     uint16_t keyId = Macros_TryConsumeKeyId(ctx);
 
@@ -703,11 +703,11 @@ static macro_variable_t backlight(parser_context_t* ctx, set_command_action_t ac
         return backlightStrategy(ctx, action);
     }
     else if (ConsumeToken(ctx, "constantRgb")) {
-        ConsumeUntilDot(ctx);
+        ConsumeOneDot(ctx);
         return constantRgb(ctx, action);
     }
     else if (ConsumeToken(ctx, "keyRgb")) {
-        ConsumeUntilDot(ctx);
+        ConsumeOneDot(ctx);
         return keyRgb(ctx, action);
     }
     else {
@@ -756,7 +756,7 @@ static macro_variable_t navigationModeAction(parser_context_t* ctx, set_command_
 
     navigationMode = ConsumeNavigationModeId(ctx);
 
-    ConsumeUntilDot(ctx);
+    ConsumeOneDot(ctx);
 
     if (action == SetCommandAction_Read) {
         Macros_ReportErrorPos(ctx, "Reading actions is not supported!");
@@ -810,7 +810,7 @@ static macro_variable_t keymapAction(parser_context_t* ctx, set_command_action_t
     uint8_t layerId = Macros_ConsumeLayerId(ctx);
     CTX_COPY(keyIdPos, *ctx);
 
-    ConsumeUntilDot(ctx);
+    ConsumeOneDot(ctx);
 
     uint16_t keyId = Macros_TryConsumeKeyId(ctx);
 
@@ -960,47 +960,47 @@ static macro_variable_t setMaxVoltage(parser_context_t* ctx, set_command_action_
 static macro_variable_t root(parser_context_t* ctx, set_command_action_t action)
 {
     if (ConsumeToken(ctx, "module")) {
-        ConsumeUntilDot(ctx);
+        ConsumeOneDot(ctx);
         return module(ctx, action);
     }
     else if (ConsumeToken(ctx, "secondaryRole")) {
-        ConsumeUntilDot(ctx);
+        ConsumeOneDot(ctx);
         return secondaryRoles(ctx, action);
     }
     else if (ConsumeToken(ctx, "bluetooth")) {
-        ConsumeUntilDot(ctx);
+        ConsumeOneDot(ctx);
         return bluetooth(ctx, action);
     }
     else if (ConsumeToken(ctx, "mouseKeys")) {
-        ConsumeUntilDot(ctx);
+        ConsumeOneDot(ctx);
         return mouseKeys(ctx, action);
     }
     else if (ConsumeToken(ctx, "keymapAction")) {
-        ConsumeUntilDot(ctx);
+        ConsumeOneDot(ctx);
         return keymapAction(ctx, action);
     }
     else if (ConsumeToken(ctx, "navigationModeAction")) {
-        ConsumeUntilDot(ctx);
+        ConsumeOneDot(ctx);
         return navigationModeAction(ctx, action);
     }
     else if (ConsumeToken(ctx, "macroEngine")) {
-        ConsumeUntilDot(ctx);
+        ConsumeOneDot(ctx);
         return macroEngine(ctx, action);
     }
     else if (ConsumeToken(ctx, "backlight")) {
-        ConsumeUntilDot(ctx);
+        ConsumeOneDot(ctx);
         return backlight(ctx, action);
     }
     else if (ConsumeToken(ctx, "battery")) {
-        ConsumeUntilDot(ctx);
+        ConsumeOneDot(ctx);
         return battery(ctx, action);
     }
     else if (ConsumeToken(ctx, "leds")) {
-        ConsumeUntilDot(ctx);
+        ConsumeOneDot(ctx);
         return leds(ctx, action);
     }
     else if (ConsumeToken(ctx, "modifierLayerTriggers")) {
-        ConsumeUntilDot(ctx);
+        ConsumeOneDot(ctx);
         return modLayerTriggers(ctx, action);
     }
     else if (ConsumeToken(ctx, "maxVoltage")) {

--- a/right/src/macros/status_buffer.c
+++ b/right/src/macros/status_buffer.c
@@ -224,7 +224,7 @@ static uint16_t findPosition(const char* arg)
     const char* startOfLine = S->ms.currentMacroAction.cmd.text + S->ls->ms.commandBegin;
     const char* endOfLine = S->ms.currentMacroAction.cmd.text + S->ls->ms.commandEnd;
 
-    if (arg < startOfLine || endOfLine < arg) {
+    if (arg < startOfLine || arg > endOfLine) {
         return 1;
     }
     return arg - startOfLine + 1;
@@ -240,7 +240,7 @@ static uint16_t findPositionCtx(const parser_context_t* ctx)
         ctx = ViewContext(0);
     }
 
-    if (ctx->at < ctx->begin || ctx->end < ctx->at) {
+    if (ctx->at < ctx->begin || ctx->at > ctx->end) {
         return 1;
     }
 
@@ -293,9 +293,9 @@ static void reportCommandLocation(uint16_t line, uint16_t pos, const char* begin
 }
 
 static void reportLocationStackLevel(const parser_context_t* ctx, uint16_t line, uint8_t indent) {
-    uint16_t pos = ctx->at - ctx->begin;
-    bool positionIsValid = ctx->begin <= ctx->at && ctx->at <= ctx->end;
+    bool positionIsValid = ctx->at >= ctx->begin && ctx->at <= ctx->end;
     if (positionIsValid) {
+        uint16_t pos = ctx->at - ctx->begin;
         reportCommandLocation(line, pos, ctx->begin, ctx->end, positionIsValid, indent);
     } else {
         Macros_SetStatusString("> Position not available here.\n", NULL);
@@ -320,7 +320,6 @@ static void reportError(
     Macros_SetStatusString(err, NULL);
 
     if (S != NULL) {
-        bool argIsCommand = ValidatedUserConfigBuffer.buffer <= (uint8_t*)arg && (uint8_t*)arg < ValidatedUserConfigBuffer.buffer + USER_CONFIG_SIZE;
         if (arg != NULL && arg != argEnd) {
             Macros_SetStatusString(" ", NULL);
             Macros_SetStatusString(arg, TokEnd(arg, argEnd));
@@ -329,7 +328,8 @@ static void reportError(
         const char* startOfLine = S->ms.currentMacroAction.cmd.text + S->ls->ms.commandBegin;
         const char* endOfLine = S->ms.currentMacroAction.cmd.text + S->ls->ms.commandEnd;
         uint16_t line = findCurrentCommandLine();
-        if (startOfLine <= arg && arg <= endOfLine) {
+        if (arg != NULL && argEnd != NULL && argEnd >= startOfLine && arg <= endOfLine) {
+            bool argIsCommand = (uint8_t*)arg >= ValidatedUserConfigBuffer.buffer && (uint8_t*)arg < ValidatedUserConfigBuffer.buffer + USER_CONFIG_SIZE;
             reportCommandLocation(line, arg - startOfLine, startOfLine, endOfLine, argIsCommand, 0);
         } else if (ctx != NULL) {
             reportLocationStack(ctx, line);

--- a/right/src/macros/string_reader.c
+++ b/right/src/macros/string_reader.c
@@ -14,6 +14,11 @@
 
 // new code:
 
+static char consumeExpressionCharOfInt(const macro_variable_t* variable, uint16_t* idx);
+static char consumeExpressionCharOfFloat(const macro_variable_t* variable, uint16_t* idx);
+static char consumeExpressionCharOfBool(const macro_variable_t* variable, uint16_t* idx);
+static char consumeExpressionCharOfString(const macro_variable_t* variable, uint16_t* idx);
+static char consumeCharOfTemplate(parser_context_t* ctx, string_type_t stringType, uint16_t* index);
 static char consumeExpressionChar(parser_context_t* ctx, string_type_t stringType, uint16_t* index);
 
 static char StrRead_consumeExpressionChar(parser_context_t* ctx, string_reader_context_t* stringCtx);

--- a/right/src/macros/string_reader.c
+++ b/right/src/macros/string_reader.c
@@ -52,7 +52,7 @@ static char StrRead_tryConsumeAnotherStringLiteral(parser_context_t *ctx, string
 
 static char StrRead_ConsumeCharInString(parser_context_t* ctx, string_reader_context_t* stringCtx)
 {
-    char* at = stringCtx->at;
+    const char* at = stringCtx->at;
     if (at >= ctx->end) {
         return '\0';
     }
@@ -104,7 +104,7 @@ static char StrRead_ConsumeCharInString(parser_context_t* ctx, string_reader_con
                     .nestingBound = ctx->nestingLevel,
                 };
                 ConsumeCommentsAsWhite(false);
-                char res = consumeExpressionChar(&ctx2, stringCtx->stringType, stringCtx->subIndex);
+                char res = consumeExpressionChar(&ctx2, stringCtx->stringType, &stringCtx->subIndex);
                 ConsumeCommentsAsWhite(true);
 
                 if (ctx2.nestingLevel != ctx->nestingLevel) {

--- a/right/src/macros/string_reader.c
+++ b/right/src/macros/string_reader.c
@@ -31,6 +31,8 @@ typedef struct {
 } string_reader_context_t;
 
 static char consumeExpressionChar(parser_context_t* ctx, string_type_t stringType, uint16_t* index);
+static char StrRead_consumeExpressionChar(parser_context_t* ctx, string_context_t* stringCtx);
+static char StrRead_consumeExpressionCharOfString(const macro_variable_t* variable, uint16_t* idx);
 
 static void StrRead_InitContext(parser_context_t* ctx, string_reader_context_t* stringCtx, string_reader_mode_t mode)
 {
@@ -57,14 +59,20 @@ static char StrRead_ConsumeCharInString(parser_context_t* ctx, string_reader_con
         return '\0';
     }
 
+    if(stringCtx->stringType == StringType_Verbatim) {
+        char res = *at;
+        stringCtx->at++;
+        return res;
+    }
+
     switch(*at) {
         case '\\':
-            if (stringCtx->stringType == StringType_SingleQuote || stringCtx->at+1 >= ctx->end) {
+            if (stringCtx->stringType == StringType_SingleQuote || at+1 >= ctx->end) {
                 goto normalChar;
             } else {
                 stringCtx->index++;
                 at++;
-                switch (*stringCtx->at) {
+                switch (*at) {
                     case 'n':
                         stringCtx->index++;
                         return '\n';
@@ -95,6 +103,7 @@ static char StrRead_ConsumeCharInString(parser_context_t* ctx, string_reader_con
             if (stringCtx->stringType == StringType_SingleQuote) {
                 goto normalChar;
             } else {
+                // new context at $ (e.g. $macroArg.1 blah blah)
                 parser_context_t ctx2 = {
                     .macroState = ctx->macroState,
                     .begin = ctx->begin,
@@ -103,9 +112,10 @@ static char StrRead_ConsumeCharInString(parser_context_t* ctx, string_reader_con
                     .nestingLevel = ctx->nestingLevel,
                     .nestingBound = ctx->nestingLevel,
                 };
-                ConsumeCommentsAsWhite(false);
-                char res = consumeExpressionChar(&ctx2, stringCtx->stringType, &stringCtx->subIndex);
-                ConsumeCommentsAsWhite(true);
+
+                ConsumeCommentsAsWhite(false); // a bit of a hack, turn off comments processing
+                char res = StrRead_consumeExpressionChar(&ctx2, stringCtx);
+                ConsumeCommentsAsWhite(true);  // turn it back on
 
                 if (ctx2.nestingLevel != ctx->nestingLevel) {
                     Macros_ReportError("Macro template has overflown expression boundary! Undefined behavior coming!", ctx2.at, ctx2.end);
@@ -190,6 +200,76 @@ static char StrRead_ConsumeCharOfString(parser_context_t* ctx, string_reader_con
         return res;
     }
 }
+
+extern string_segment_t StringRefToSegment(string_ref_t ref);
+
+static char StrRead_consumeExpressionCharOfString(const macro_variable_t* variable, uint16_t* idx)
+{
+    // read the nth character of the string variable, where n is the value of *idx. 
+    // If n exceeds the string length, return '\0' and reset *idx to 0.
+
+    string_segment_t str = StringRefToSegment(variable->asStringRef);
+    uint8_t len = str.end - str.start;
+
+    if (*idx < len) {
+        char c = str.start[*idx];
+        (*idx)++;
+        return c;
+    } else {
+        *idx = 0;    
+        return '\0';
+    }
+}
+
+static char StrRead_consumeExpressionChar(parser_context_t* ctx, string_context_t* stringCtx)
+{
+    char c;
+
+    // TODO: this TRY_EXPAND_TEMPLATE won't be needed if we expand $macroArg:any correctly.
+    //       It will be handled automatically in Macros_ConsumeAnyValue() below.
+    if (TRY_EXPAND_TEMPLATE(ctx)) {
+        // Call tree of this never expands or unexpands this context, so we can safely perform a pop after.
+        // (If there is an expansion, it is handled within a new context copy.)
+        c = consumeCharOfTemplate(ctx, stringCtx->stringType, &stringCtx->subIndex);
+        PopParserContext(ctx);
+
+        if (stringCtx->subIndex == 0) {
+            UnconsumeWhite(ctx);
+        }
+        return c;
+    } else {
+        macro_variable_t res = Macros_ConsumeAnyValue(ctx);
+        UnconsumeWhite(ctx);
+
+        switch (res.type) {
+            case MacroVariableType_Int:
+                c = consumeExpressionCharOfInt(&res, &stringCtx->subIndex);
+                break;
+            case MacroVariableType_Float:
+                c = consumeExpressionCharOfFloat(&res, &stringCtx->subIndex);
+                break;
+            case MacroVariableType_Bool:
+                c = consumeExpressionCharOfBool(&res, &stringCtx->subIndex);
+                break;
+            case MacroVariableType_String:
+                c = StrRead_consumeExpressionCharOfString(&res, &stringCtx->subIndex);
+                break;
+            case MacroVariableType_None:
+                c = '?';
+                break;
+            default:
+                Macros_ReportErrorNum("Unrecognized variable type", res.type, ctx->at);
+                return '\0';
+        }
+    }
+
+    if (Macros_ParserError) {
+        ctx->at++;
+        stringCtx->subIndex = 0;
+    }
+    return c;
+}
+
 
 // existing code:
 

--- a/right/src/macros/string_reader.c
+++ b/right/src/macros/string_reader.c
@@ -16,7 +16,7 @@
 
 static char consumeExpressionChar(parser_context_t* ctx, string_type_t stringType, uint16_t* index);
 
-static char StrRead_consumeExpressionChar(parser_context_t* ctx, string_context_t* stringCtx);
+static char StrRead_consumeExpressionChar(parser_context_t* ctx, string_reader_context_t* stringCtx);
 static char StrRead_consumeExpressionCharOfString(const macro_variable_t* variable, uint16_t* idx);
 
 void StrRead_InitContext(parser_context_t* ctx, string_reader_context_t* stringCtx, string_reader_mode_t mode)
@@ -206,7 +206,7 @@ static char StrRead_consumeExpressionCharOfString(const macro_variable_t* variab
     }
 }
 
-static char StrRead_consumeExpressionChar(parser_context_t* ctx, string_context_t* stringCtx)
+static char StrRead_consumeExpressionChar(parser_context_t* ctx, string_reader_context_t* stringCtx)
 {
     char c;
 

--- a/right/src/macros/string_reader.c
+++ b/right/src/macros/string_reader.c
@@ -14,14 +14,6 @@
 
 // new code:
 
-typedef enum {
-    StringType_Undetermined = 0,
-    StringType_Raw,
-    StringType_DoubleQuote,
-    StringType_SingleQuote,
-    StringType_Verbatim,
-} string_type_t;
-
 static char consumeExpressionChar(parser_context_t* ctx, string_type_t stringType, uint16_t* index);
 
 static char StrRead_consumeExpressionChar(parser_context_t* ctx, string_context_t* stringCtx);

--- a/right/src/macros/string_reader.c
+++ b/right/src/macros/string_reader.c
@@ -273,7 +273,7 @@ static char StrRead_consumeExpressionChar(parser_context_t* ctx, string_reader_c
                 c = consumeExpressionCharOfBool(&res, &stringCtx->subIndex);
                 break;
             case MacroVariableType_String:
-                c = StrRead_consumeExpressionCharOfString(&res, &stringCtx->subIndex);
+                c = /*StrRead_*/consumeExpressionCharOfString(&res, &stringCtx->subIndex);
                 break;
             case MacroVariableType_None:
                 c = '?';

--- a/right/src/macros/string_reader.c
+++ b/right/src/macros/string_reader.c
@@ -288,7 +288,7 @@ static char StrRead_consumeExpressionChar(parser_context_t* ctx, string_reader_c
 }
 
 
-// existing code:
+// existing code:a  
 
 static char Macros_ConsumeCharInString(parser_context_t* ctx, string_type_t stringType, const char* at, uint16_t* index, uint16_t* subIndex);
 

--- a/right/src/macros/string_reader.c
+++ b/right/src/macros/string_reader.c
@@ -51,7 +51,7 @@ static char StrRead_ConsumeCharInString(parser_context_t* ctx, string_reader_con
 
     if(stringCtx->stringType == StringType_Verbatim) {
         char res = *at;
-        stringCtx->at++;
+        stringCtx->index++;
         return res;
     }
 
@@ -149,6 +149,7 @@ char StrRead_ConsumeCharOfString(parser_context_t* ctx, string_reader_context_t*
     at += stringCtx->stringOffset;  // point to the current literal of the string.
 
     if (stringCtx->stringType == StringType_Verbatim) {
+        stringCtx->at = at + stringCtx->index;
         char res = StrRead_ConsumeCharInString(ctx, stringCtx);
         // I don't think we even need this part; for verbatim strings, there cannot be another part.
         if (res == '\0') {

--- a/right/src/macros/string_reader.c
+++ b/right/src/macros/string_reader.c
@@ -230,7 +230,11 @@ static char StrRead_consumeExpressionCharOfString(const macro_variable_t* variab
 
     if (*idx < len) {
         char c = str.start[*idx];
-        (*idx)++;
+        if (c != '\0') {
+            (*idx)++;
+        } else {
+            *idx = 0;
+        }
         return c;
     } else {
         *idx = 0;    

--- a/right/src/macros/string_reader.c
+++ b/right/src/macros/string_reader.c
@@ -43,7 +43,6 @@ static void StrRead_InitContext(parser_context_t* ctx, string_reader_context_t* 
     }
 }
 
-#if 0
 static char StrRead_ConsumeCharInString(parser_context_t* ctx, string_reader_context_t* stringCtx)
 {
     if (at >= ctx->end) {
@@ -52,32 +51,32 @@ static char StrRead_ConsumeCharInString(parser_context_t* ctx, string_reader_con
 
     switch(*at) {
         case '\\':
-            if (stringType == StringType_SingleQuote || at+1 == ctx->end) {
+            if (stringCtx->stringType == StringType_SingleQuote || at+1 == ctx->end) {
                 goto normalChar;
             } else {
-                (*index)++;
+                stringCtx->index++;
                 at++;
                 switch (*at) {
                     case 'n':
-                        (*index)++;
+                        stringCtx->index++;
                         return '\n';
                     default:
-                        (*index)++;
+                        stringCtx->index++;
                         return *at;
                 }
             }
         case '"':
-            if (stringType == StringType_DoubleQuote) {
+            if (stringCtx->stringType == StringType_DoubleQuote) {
                 at++;
-                (*index)++;
+                stringCtx->index++;
                 return '\0';
             } else {
                 goto normalChar;
             }
         case '\'':
-            if (stringType == StringType_SingleQuote) {
+            if (stringCtx->stringType == StringType_SingleQuote) {
                 at++;
-                (*index)++;
+                stringCtx->index++;
                 return '\0';
             } else {
                 goto normalChar;
@@ -85,7 +84,7 @@ static char StrRead_ConsumeCharInString(parser_context_t* ctx, string_reader_con
         case '\n':
             return '\0';
         case '$':
-            if (stringType == StringType_SingleQuote) {
+            if (stringCtx->stringType == StringType_SingleQuote) {
                 goto normalChar;
             } else {
                 parser_context_t ctx2 = {
@@ -97,7 +96,7 @@ static char StrRead_ConsumeCharInString(parser_context_t* ctx, string_reader_con
                     .nestingBound = ctx->nestingLevel,
                 };
                 ConsumeCommentsAsWhite(false);
-                char res = consumeExpressionChar(&ctx2, stringType, subIndex);
+                char res = consumeExpressionChar(&ctx2, stringCtx->stringType, stringCtx->subIndex);
                 ConsumeCommentsAsWhite(true);
 
                 if (ctx2.nestingLevel != ctx->nestingLevel) {
@@ -108,26 +107,42 @@ static char StrRead_ConsumeCharInString(parser_context_t* ctx, string_reader_con
                     return '$';
                 }
 
-                if (*subIndex == 0) {
-                    *index += ctx2.at - at;
+                if (stringCtx->subIndex == 0) {
+                    stringCtx->index += ctx2.at - at;
                 }
                 return res;
             }
         default:
         normalChar:
-            (*index)++;
+            stringCtx->index++;
             return *at;
     }
 }
+
+// A string can be either a verbatim string (without quotes, with no support for escapes and expansions), 
+// a raw string (without quotes, with support for escapes and expansions), or a series of string literals. 
+// Each literal is either a double-quoted string (with support for escapes and expansions), or
+// a single-quoted string (with support for only a single-quote-escape but no expansions). 
+// Literals are concatenated without any interventing characters.
+
+// For example, the following are all valid strings:
+// hello $worldname world         => raw string with expansions, so $worldname is expanded.
+// "hello"' $worldname '"world"   => three literals: double-quoted string, single-quoted string, double-quoted string
+//                                   the single-quoted part prevents expansions in that part, so $worldname is not expanded.
+// "hello \"$worldname\" world"   => double-quoted string with escapes and expansions, so $worldname is expanded, and remains double-quoted due to the escapes.
+
+// If any of these examples are read as a verbatim string, all the characters will be read 
+// verbatim (as-is) until the end of the context, including all $ signs and quotes (no expansions, no escapes).
 
 static char StrRead_ConsumeCharOfString(parser_context_t* ctx, string_reader_context_t* stringCtx, string_reader_mode_t mode)
 {
     const char* at = ctx->at;
 
-    at += stringCtx->stringOffset;
+    at += stringCtx->stringOffset;  // point to the next literal part of the string.
 
     if (stringCtx->stringType == StringType_Verbatim) {
         char res = StrRead_ConsumeCharInString(ctx, stringCtx);
+        // I don't think we even need this part; for verbatim strings, there cannot be another part.
         if (res == '\0') {
             stringCtx->stringOffset += stringCtx->index;
             stringCtx->index = 0;
@@ -135,24 +150,23 @@ static char StrRead_ConsumeCharOfString(parser_context_t* ctx, string_reader_con
         return res;
     }
 
-    string_type_t stringType;
     switch (*at) {
         case '\'':
-            stringType = StringType_SingleQuote;
+            stringCtx->stringType = StringType_SingleQuote;
             break;
         case '"':
-            stringType = StringType_DoubleQuote;
+            stringCtx->stringType = StringType_DoubleQuote;
             break;
         default:
-            stringType = StringType_Raw;
+            stringCtx->stringType = StringType_Raw;
             break;
     }
 
-    if (*index == 0 && stringType != StringType_Raw) {
-        (*index)++;
+    if (stringCtx->index == 0 && stringCtx->stringType != StringType_Raw) {
+        stringCtx->index++;
     }
 
-    at += *index;
+    at += stringCtx->index;
 
     // (This is correct, we don't want a context pop here.)
     if (at == ctx->end) {
@@ -160,15 +174,14 @@ static char StrRead_ConsumeCharOfString(parser_context_t* ctx, string_reader_con
         return '\0';
     }
 
-    char maybeRes = Macros_ConsumeCharInString(ctx, stringType, at, index, subIndex);
+    char maybeRes = StrRead_ConsumeCharInString(ctx, stringCtx);
 
     if (maybeRes == '\0') {
-        return tryConsumeAnotherStringLiteral(ctx, stringOffset, index, subIndex);
+        return StrRead_tryConsumeAnotherStringLiteral(ctx, stringCtx);
     } else {
         return maybeRes;
     }
 }
-#endif
 
 // existing code:
 

--- a/right/src/macros/string_reader.c
+++ b/right/src/macros/string_reader.c
@@ -30,6 +30,8 @@ typedef struct {
     string_type_t stringType;
 } string_reader_context_t;
 
+static char consumeExpressionChar(parser_context_t* ctx, string_type_t stringType, uint16_t* index);
+
 static void StrRead_InitContext(parser_context_t* ctx, string_reader_context_t* stringCtx, string_reader_mode_t mode)
 {
     stringCtx->at = ctx->at;
@@ -43,20 +45,26 @@ static void StrRead_InitContext(parser_context_t* ctx, string_reader_context_t* 
     }
 }
 
+static char StrRead_tryConsumeAnotherStringLiteral(parser_context_t *ctx, string_reader_context_t *stringCtx)
+{
+    return 0;
+}
+
 static char StrRead_ConsumeCharInString(parser_context_t* ctx, string_reader_context_t* stringCtx)
 {
+    char* at = stringCtx->at;
     if (at >= ctx->end) {
         return '\0';
     }
 
     switch(*at) {
         case '\\':
-            if (stringCtx->stringType == StringType_SingleQuote || at+1 == ctx->end) {
+            if (stringCtx->stringType == StringType_SingleQuote || stringCtx->at+1 >= ctx->end) {
                 goto normalChar;
             } else {
                 stringCtx->index++;
                 at++;
-                switch (*at) {
+                switch (*stringCtx->at) {
                     case 'n':
                         stringCtx->index++;
                         return '\n';
@@ -103,7 +111,7 @@ static char StrRead_ConsumeCharInString(parser_context_t* ctx, string_reader_con
                     Macros_ReportError("Macro template has overflown expression boundary! Undefined behavior coming!", ctx2.at, ctx2.end);
                     while (ctx2.nestingLevel > ctx->nestingLevel && PopParserContext(&ctx2)) {
                     }
-                    *index += 1;
+                    stringCtx->subIndex += 1;
                     return '$';
                 }
 
@@ -169,17 +177,17 @@ static char StrRead_ConsumeCharOfString(parser_context_t* ctx, string_reader_con
     at += stringCtx->index;
 
     // (This is correct, we don't want a context pop here.)
-    if (at == ctx->end) {
+    if (at >= ctx->end) {
         ctx->at = ctx->end;
         return '\0';
     }
 
-    char maybeRes = StrRead_ConsumeCharInString(ctx, stringCtx);
+    char res = StrRead_ConsumeCharInString(ctx, stringCtx);
 
-    if (maybeRes == '\0') {
+    if (res == '\0') {
         return StrRead_tryConsumeAnotherStringLiteral(ctx, stringCtx);
     } else {
-        return maybeRes;
+        return res;
     }
 }
 
@@ -575,4 +583,3 @@ static char Macros_ConsumeCharInString(parser_context_t* ctx, string_type_t stri
             return *at;
     }
 }
-

--- a/right/src/macros/string_reader.c
+++ b/right/src/macros/string_reader.c
@@ -12,12 +12,165 @@
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
 #endif
 
+// new code:
+
 typedef enum {
-   StringType_Raw,
-   StringType_DoubleQuote,
-   StringType_SingleQuote,
+    StringType_Undetermined = 0,
+    StringType_Raw,
+    StringType_DoubleQuote,
+    StringType_SingleQuote,
+    StringType_Verbatim,
 } string_type_t;
 
+typedef struct {
+    const char* at;
+    uint16_t stringOffset;
+    uint16_t index;
+    uint16_t subIndex;
+    string_type_t stringType;
+} string_reader_context_t;
+
+static void StrRead_InitContext(parser_context_t* ctx, string_reader_context_t* stringCtx, string_reader_mode_t mode)
+{
+    stringCtx->at = ctx->at;
+    stringCtx->stringOffset = 0;
+    stringCtx->index = 0;
+    stringCtx->subIndex = 0;
+    if (mode == StrReadMode_Verbatim) {
+        stringCtx->stringType = StringType_Verbatim;
+    } else {
+        stringCtx->stringType = StringType_Undetermined;
+    }
+}
+
+#if 0
+static char StrRead_ConsumeCharInString(parser_context_t* ctx, string_reader_context_t* stringCtx)
+{
+    if (at >= ctx->end) {
+        return '\0';
+    }
+
+    switch(*at) {
+        case '\\':
+            if (stringType == StringType_SingleQuote || at+1 == ctx->end) {
+                goto normalChar;
+            } else {
+                (*index)++;
+                at++;
+                switch (*at) {
+                    case 'n':
+                        (*index)++;
+                        return '\n';
+                    default:
+                        (*index)++;
+                        return *at;
+                }
+            }
+        case '"':
+            if (stringType == StringType_DoubleQuote) {
+                at++;
+                (*index)++;
+                return '\0';
+            } else {
+                goto normalChar;
+            }
+        case '\'':
+            if (stringType == StringType_SingleQuote) {
+                at++;
+                (*index)++;
+                return '\0';
+            } else {
+                goto normalChar;
+            }
+        case '\n':
+            return '\0';
+        case '$':
+            if (stringType == StringType_SingleQuote) {
+                goto normalChar;
+            } else {
+                parser_context_t ctx2 = {
+                    .macroState = ctx->macroState,
+                    .begin = ctx->begin,
+                    .at = at,
+                    .end = ctx->end,
+                    .nestingLevel = ctx->nestingLevel,
+                    .nestingBound = ctx->nestingLevel,
+                };
+                ConsumeCommentsAsWhite(false);
+                char res = consumeExpressionChar(&ctx2, stringType, subIndex);
+                ConsumeCommentsAsWhite(true);
+
+                if (ctx2.nestingLevel != ctx->nestingLevel) {
+                    Macros_ReportError("Macro template has overflown expression boundary! Undefined behavior coming!", ctx2.at, ctx2.end);
+                    while (ctx2.nestingLevel > ctx->nestingLevel && PopParserContext(&ctx2)) {
+                    }
+                    *index += 1;
+                    return '$';
+                }
+
+                if (*subIndex == 0) {
+                    *index += ctx2.at - at;
+                }
+                return res;
+            }
+        default:
+        normalChar:
+            (*index)++;
+            return *at;
+    }
+}
+
+static char StrRead_ConsumeCharOfString(parser_context_t* ctx, string_reader_context_t* stringCtx, string_reader_mode_t mode)
+{
+    const char* at = ctx->at;
+
+    at += stringCtx->stringOffset;
+
+    if (stringCtx->stringType == StringType_Verbatim) {
+        char res = StrRead_ConsumeCharInString(ctx, stringCtx);
+        if (res == '\0') {
+            stringCtx->stringOffset += stringCtx->index;
+            stringCtx->index = 0;
+        }
+        return res;
+    }
+
+    string_type_t stringType;
+    switch (*at) {
+        case '\'':
+            stringType = StringType_SingleQuote;
+            break;
+        case '"':
+            stringType = StringType_DoubleQuote;
+            break;
+        default:
+            stringType = StringType_Raw;
+            break;
+    }
+
+    if (*index == 0 && stringType != StringType_Raw) {
+        (*index)++;
+    }
+
+    at += *index;
+
+    // (This is correct, we don't want a context pop here.)
+    if (at == ctx->end) {
+        ctx->at = ctx->end;
+        return '\0';
+    }
+
+    char maybeRes = Macros_ConsumeCharInString(ctx, stringType, at, index, subIndex);
+
+    if (maybeRes == '\0') {
+        return tryConsumeAnotherStringLiteral(ctx, stringOffset, index, subIndex);
+    } else {
+        return maybeRes;
+    }
+}
+#endif
+
+// existing code:
 
 static char Macros_ConsumeCharInString(parser_context_t* ctx, string_type_t stringType, const char* at, uint16_t* index, uint16_t* subIndex);
 

--- a/right/src/macros/string_reader.c
+++ b/right/src/macros/string_reader.c
@@ -151,8 +151,9 @@ char StrRead_ConsumeCharOfString(parser_context_t* ctx, string_reader_context_t*
     if (stringCtx->stringType == StringType_Verbatim) {
         stringCtx->at = at + stringCtx->index;
         char res = StrRead_ConsumeCharInString(ctx, stringCtx);
-        // I don't think we even need this part; for verbatim strings, there cannot be another part.
+
         if (res == '\0') {
+            ctx->at += stringCtx->stringOffset + stringCtx->index;
             stringCtx->stringOffset += stringCtx->index;
             stringCtx->index = 0;
         }

--- a/right/src/macros/string_reader.c
+++ b/right/src/macros/string_reader.c
@@ -273,7 +273,7 @@ static char StrRead_consumeExpressionChar(parser_context_t* ctx, string_reader_c
                 c = consumeExpressionCharOfBool(&res, &stringCtx->subIndex);
                 break;
             case MacroVariableType_String:
-                c = /*StrRead_*/consumeExpressionCharOfString(&res, &stringCtx->subIndex);
+                c = StrRead_consumeExpressionCharOfString(&res, &stringCtx->subIndex);
                 break;
             case MacroVariableType_None:
                 c = '?';

--- a/right/src/macros/string_reader.c
+++ b/right/src/macros/string_reader.c
@@ -39,7 +39,7 @@ void StrRead_InitContext(parser_context_t* ctx, string_reader_context_t* stringC
 
 static char StrRead_tryConsumeAnotherStringLiteral(parser_context_t *ctx, string_reader_context_t *stringCtx)
 {
-    return 0;
+    return '\0';
 }
 
 static char StrRead_ConsumeCharInString(parser_context_t* ctx, string_reader_context_t* stringCtx)
@@ -146,7 +146,7 @@ char StrRead_ConsumeCharOfString(parser_context_t* ctx, string_reader_context_t*
 {
     const char* at = ctx->at;
 
-    at += stringCtx->stringOffset;  // point to the next literal part of the string.
+    at += stringCtx->stringOffset;  // point to the current literal of the string.
 
     if (stringCtx->stringType == StringType_Verbatim) {
         char res = StrRead_ConsumeCharInString(ctx, stringCtx);
@@ -182,9 +182,10 @@ char StrRead_ConsumeCharOfString(parser_context_t* ctx, string_reader_context_t*
         return '\0';
     }
 
+    stringCtx->at = at;
     char res = StrRead_ConsumeCharInString(ctx, stringCtx);
 
-    if (res == '\0') {
+    if (res == '\0' && stringCtx->stringType != StringType_Verbatim) {
         return StrRead_tryConsumeAnotherStringLiteral(ctx, stringCtx);
     } else {
         return res;

--- a/right/src/macros/string_reader.c
+++ b/right/src/macros/string_reader.c
@@ -39,7 +39,31 @@ void StrRead_InitContext(parser_context_t* ctx, string_reader_context_t* stringC
 
 static char StrRead_tryConsumeAnotherStringLiteral(parser_context_t *ctx, string_reader_context_t *stringCtx)
 {
-    return '\0';
+    const char* at = ctx->at + stringCtx->stringOffset + stringCtx->index;
+
+    if (at >= ctx->end) {
+        ctx->at = ctx->end;
+        return '\0';
+    }
+
+    switch (*at) {
+        case '\'':
+        case '"':
+            // advance the string reader context to the beginning quote of the next literal
+            stringCtx->stringOffset += stringCtx->index;
+            stringCtx->index = 0;
+            return StrRead_ConsumeCharOfString(ctx, stringCtx);
+        default:
+            // advance the main context to the end of the current string
+            ctx->at = at;
+            ConsumeWhite(ctx);
+            // we probably don't need to reset the string reader context here,
+            // any new string reading should call InitContext() again.
+            stringCtx->stringOffset = 0;
+            stringCtx->index = 0;
+            stringCtx->subIndex = 0;
+            return '\0';
+    }
 }
 
 static char StrRead_ConsumeCharInString(parser_context_t* ctx, string_reader_context_t* stringCtx)

--- a/right/src/macros/string_reader.c
+++ b/right/src/macros/string_reader.c
@@ -148,6 +148,9 @@ static char consumeExpressionCharOfString(const macro_variable_t* variable, uint
 static char consumeExpressionChar(parser_context_t* ctx, string_type_t stringType, uint16_t* index)
 {
     char c;
+
+    // TODO: this TRY_EXPAND_TEMPLATE won't be needed if we expand $macroArg:any correctly.
+    //       It will be handled automatically in Macros_ConsumeAnyValue() below.
     if (TRY_EXPAND_TEMPLATE(ctx)) {
         // Call tree of this never expands or unexpands this context, so we can safely perform a pop after.
         // (If there is an expansion, it is handled within a new context copy.)
@@ -330,7 +333,6 @@ char Macros_ConsumeCharOfString(parser_context_t* ctx, uint16_t* stringOffset, u
         return maybeRes;
     }
 }
-
 
 static char Macros_ConsumeCharInString(parser_context_t* ctx, string_type_t stringType, const char* at, uint16_t* index, uint16_t* subIndex)
 {

--- a/right/src/macros/string_reader.c
+++ b/right/src/macros/string_reader.c
@@ -19,7 +19,7 @@ static char consumeExpressionChar(parser_context_t* ctx, string_type_t stringTyp
 static char StrRead_consumeExpressionChar(parser_context_t* ctx, string_context_t* stringCtx);
 static char StrRead_consumeExpressionCharOfString(const macro_variable_t* variable, uint16_t* idx);
 
-static void StrRead_InitContext(parser_context_t* ctx, string_reader_context_t* stringCtx, string_reader_mode_t mode)
+void StrRead_InitContext(parser_context_t* ctx, string_reader_context_t* stringCtx, string_reader_mode_t mode)
 {
     stringCtx->at = ctx->at;
     stringCtx->stringOffset = 0;
@@ -137,7 +137,7 @@ static char StrRead_ConsumeCharInString(parser_context_t* ctx, string_reader_con
 // If any of these examples are read as a verbatim string, all the characters will be read 
 // verbatim (as-is) until the end of the context, including all $ signs and quotes (no expansions, no escapes).
 
-static char StrRead_ConsumeCharOfString(parser_context_t* ctx, string_reader_context_t* stringCtx)
+char StrRead_ConsumeCharOfString(parser_context_t* ctx, string_reader_context_t* stringCtx)
 {
     const char* at = ctx->at;
 

--- a/right/src/macros/string_reader.c
+++ b/right/src/macros/string_reader.c
@@ -22,15 +22,8 @@ typedef enum {
     StringType_Verbatim,
 } string_type_t;
 
-typedef struct {
-    const char* at;
-    uint16_t stringOffset;
-    uint16_t index;
-    uint16_t subIndex;
-    string_type_t stringType;
-} string_reader_context_t;
-
 static char consumeExpressionChar(parser_context_t* ctx, string_type_t stringType, uint16_t* index);
+
 static char StrRead_consumeExpressionChar(parser_context_t* ctx, string_context_t* stringCtx);
 static char StrRead_consumeExpressionCharOfString(const macro_variable_t* variable, uint16_t* idx);
 
@@ -152,7 +145,7 @@ static char StrRead_ConsumeCharInString(parser_context_t* ctx, string_reader_con
 // If any of these examples are read as a verbatim string, all the characters will be read 
 // verbatim (as-is) until the end of the context, including all $ signs and quotes (no expansions, no escapes).
 
-static char StrRead_ConsumeCharOfString(parser_context_t* ctx, string_reader_context_t* stringCtx, string_reader_mode_t mode)
+static char StrRead_ConsumeCharOfString(parser_context_t* ctx, string_reader_context_t* stringCtx)
 {
     const char* at = ctx->at;
 

--- a/right/src/macros/string_reader.h
+++ b/right/src/macros/string_reader.h
@@ -21,7 +21,7 @@
 
 typedef enum {
     StrReadMode_Verbatim, // do not expand anything in the string. Reads until end of context.
-    StrReadMode_Literal,  // read a string literal, with support for escapes and $-expansions.
+    StrReadMode_Literal,  // read a string literal, with support for quotes, escapes and $-expansions.
 } string_reader_mode_t;
 
 // Variables:

--- a/right/src/macros/string_reader.h
+++ b/right/src/macros/string_reader.h
@@ -24,6 +24,14 @@ typedef enum {
     StrReadMode_Literal,  // read a string literal, with support for quotes, escapes and $-expansions.
 } string_reader_mode_t;
 
+typedef enum {
+    StringType_Undetermined = 0,
+    StringType_Raw,
+    StringType_DoubleQuote,
+    StringType_SingleQuote,
+    StringType_Verbatim,
+} string_type_t;
+
 typedef struct {
     const char* at;
     uint16_t stringOffset;

--- a/right/src/macros/string_reader.h
+++ b/right/src/macros/string_reader.h
@@ -24,6 +24,14 @@ typedef enum {
     StrReadMode_Literal,  // read a string literal, with support for quotes, escapes and $-expansions.
 } string_reader_mode_t;
 
+typedef struct {
+    const char* at;
+    uint16_t stringOffset;
+    uint16_t index;
+    uint16_t subIndex;
+    string_type_t stringType;
+} string_reader_context_t;
+
 // Variables:
 
 // Functions:
@@ -32,6 +40,9 @@ typedef enum {
     bool Macros_CompareStringRefs(string_ref_t ref1, string_ref_t ref2);
     bool Macros_CompareStringToken(parser_context_t* ctx, string_segment_t str);
     void Macros_ConsumeStringToken(parser_context_t* ctx);
+
+    static void StrRead_InitContext(parser_context_t* ctx, string_reader_context_t* stringCtx, string_reader_mode_t mode);
+    static char StrRead_ConsumeCharOfString(parser_context_t* ctx, string_reader_context_t* stringCtx);
 
 #endif
 

--- a/right/src/macros/string_reader.h
+++ b/right/src/macros/string_reader.h
@@ -19,7 +19,10 @@
 
 // Typedefs:
 
-
+typedef enum {
+    StrReadMode_Verbatim, // do not expand anything in the string. Reads until end of context.
+    StrReadMode_Literal,  // read a string literal, with support for escapes and $-expansions.
+} string_reader_mode_t;
 
 // Variables:
 

--- a/right/src/macros/string_reader.h
+++ b/right/src/macros/string_reader.h
@@ -49,8 +49,8 @@ typedef struct {
     bool Macros_CompareStringToken(parser_context_t* ctx, string_segment_t str);
     void Macros_ConsumeStringToken(parser_context_t* ctx);
 
-    static void StrRead_InitContext(parser_context_t* ctx, string_reader_context_t* stringCtx, string_reader_mode_t mode);
-    static char StrRead_ConsumeCharOfString(parser_context_t* ctx, string_reader_context_t* stringCtx);
+    void StrRead_InitContext(parser_context_t* ctx, string_reader_context_t* stringCtx, string_reader_mode_t mode);
+    char StrRead_ConsumeCharOfString(parser_context_t* ctx, string_reader_context_t* stringCtx);
 
 #endif
 

--- a/right/src/macros/vars.c
+++ b/right/src/macros/vars.c
@@ -80,6 +80,11 @@ static macro_variable_t intVar(int32_t value)
     return (macro_variable_t) { .asInt = value, .type = MacroVariableType_Int };
 }
 
+static macro_variable_t floatVar(float value)
+{
+    return (macro_variable_t) { .asFloat = value, .type = MacroVariableType_Float };
+}
+
 static macro_variable_t boolVar(bool value)
 {
     return (macro_variable_t) { .asBool = value, .type = MacroVariableType_Bool };
@@ -154,24 +159,43 @@ static macro_variable_t consumeNumericValue(parser_context_t* ctx)
 static macro_variable_t consumeBool(parser_context_t* ctx)
 {
     if (ConsumeToken(ctx, "false")) {
-        return (macro_variable_t){ .type = MacroVariableType_Bool, .asBool = false };
+        return boolVar(false);
     } 
     else if (ConsumeToken(ctx, "true")) {
-        return (macro_variable_t){ .type = MacroVariableType_Bool, .asBool = true };
+        return boolVar(true);
     }
 
     Macros_ReportErrorTok(ctx, "Boolean value (true/false) expected but found:");
     return noneVar();
 }
 
-static macro_variable_t consumeRawStringNonExpanded(parser_context_t* ctx)
+static macro_variable_t consumeKeyIdValue(parser_context_t* ctx)
+{
+    uint8_t keyId = MacroKeyIdParser_TryConsumeKeyId(ctx);
+    if (keyId == 255) {
+        macro_variable_t res = consumeValue(ctx);
+        return coalesceType(ctx, res, MacroVariableType_Int);
+    }
+    return intVar(keyId);
+}
+
+static macro_variable_t consumeScancodeValue(parser_context_t* ctx)
+// consume "scancode" = modded scancode = "shortcut", return as string variable.
+{
+    const char* atStart = ctx->at;
+    // should preparse the Mods+Scancode for validity.
+    // macro_action_t action = decodeKeyAndConsume(ctx, MacroSubAction_None);
+    // const char* atEnd = ctx->at;
+    const char* atEnd = TokEnd(ctx->at, ctx->end);
+    ConsumeWhiteAt(ctx, atEnd);
+
+    return stringVar(createStringRef(atStart, atEnd));
+}
+
+static macro_variable_t consumeStringVerbatim(parser_context_t* ctx)
 {
     // the remaining context is the string. No expansions.
-    uint16_t offset = ctx->at - (const char*)ValidatedUserConfigBuffer.buffer;
-    uint8_t len = ctx->end - ctx->at;
-    ctx->at = ctx->end;
-
-    return stringVar((string_ref_t){ .offset = offset, .len = len });
+    return stringVar(createStringRef(ctx->at, ctx->end));
 }
 
 static macro_variable_t consumeStringLiteral(parser_context_t* ctx)
@@ -186,10 +210,7 @@ static macro_variable_t consumeStringLiteral(parser_context_t* ctx)
         return noneVar();
     }
 
-    uint16_t offset = stringStart - (const char*)ValidatedUserConfigBuffer.buffer;
-    uint8_t len = ctx->at - stringStart;
-
-    return stringVar((string_ref_t){ .offset = offset, .len = len });
+    return stringVar(createStringRef(stringStart, ctx->at));
 }
 
 macro_variable_t* Macros_ConsumeExistingWritableVariable(parser_context_t* ctx)
@@ -414,7 +435,7 @@ static macro_variable_t consumeDollarExpression(parser_context_t* ctx)
         ConsumeUntilDot(ctx);
         uint8_t keyId = MacroKeyIdParser_TryConsumeKeyId(ctx);
         if (keyId == 255) {
-            Macros_ReportErrorTok(ctx, "KeyId abbreviation expected");
+            Macros_ReportErrorTok(ctx, "KeyId abbreviation expected:");
             return noneVar();
         }
         return intVar(keyId);
@@ -961,6 +982,16 @@ bool Macros_ConsumeBool(parser_context_t* ctx)
     return coalesceType(ctx, res, MacroVariableType_Bool).asBool;
 }
 
+string_segment_t Macros_ConsumeString(parser_context_t* ctx)
+{
+    macro_variable_t res = consumeValue(ctx);
+    if (res.type != MacroVariableType_String) {
+        // Macros_ReportError("String value expected but found:", NULL, NULL);
+        return (string_segment_t){ .start = NULL, .end = NULL };
+    }
+    return stringRefToSegment(res.asStringRef);
+}
+
 macro_variable_t Macros_ConsumeAnyValue(parser_context_t *ctx)
 {
     return consumeValue(ctx);
@@ -977,7 +1008,23 @@ macro_result_t Macros_ProcessSetVarCommand(parser_context_t* ctx)
 
     if (dst != NULL) {
         dst->type = src.type;
-        dst->asInt = src.asInt;
+        switch (src.type) {
+            case MacroVariableType_Int:
+                dst->asInt = src.asInt;
+                break;
+            case MacroVariableType_Float:
+                dst->asFloat = src.asFloat;
+                break;
+            case MacroVariableType_Bool:
+                dst->asBool = src.asBool;
+                break;
+            case MacroVariableType_String:
+                dst->asStringRef = src.asStringRef;
+                break;
+            default:
+                Macros_ReportErrorNum("Unexpected variable type:", src.type, NULL);
+                break;
+        }
     }
 
     return MacroResult_Finished;
@@ -1154,11 +1201,15 @@ static macro_variable_t consumeArgumentAsValue(parser_context_t* ctx) {
             case MacroArgType_String: {
                 // this used to be consumeStringLiteral, but that leads to $-expansions
                 // within the string, even if not enclosed in double-quotes. 
-                // Values configured for arguments should be interpreted as raw strings 
+                // Values configured for arguments should be interpreted as verbatim strings 
                 // without expansions.
                 // Use type 'any' if you want $-expansions in your arguments.
-                return consumeRawStringNonExpanded(&varCtx);
+                return consumeStringVerbatim(&varCtx);
             }
+            case MacroArgType_KeyId:
+                return consumeKeyIdValue(&varCtx);
+            case MacroArgType_ScanCode:
+                return consumeScancodeValue(&varCtx);
             default:
                 Macros_ReportErrorNum("Unexpected argument type:", argType, NULL);
                 return noneVar();

--- a/right/src/macros/vars.c
+++ b/right/src/macros/vars.c
@@ -177,8 +177,7 @@ static macro_variable_t consumeKeyIdValue(parser_context_t* ctx)
 {
     uint8_t keyId = MacroKeyIdParser_TryConsumeKeyId(ctx);
     if (keyId == 255) {
-        macro_variable_t res = consumeValue(ctx);
-        return coalesceType(ctx, res, MacroVariableType_Int);
+        return consumeIntValue(ctx);
     }
     return intVar(keyId);
 }

--- a/right/src/macros/vars.c
+++ b/right/src/macros/vars.c
@@ -532,12 +532,16 @@ static macro_variable_t consumeValue(parser_context_t* ctx)
     }
 
 failed:
+    return consumeStringLiteral(ctx);
+
+#if 0
     if (IsIdentifierChar(*ctx->at)) {
         Macros_ReportErrorPrintf(ctx->at, "Parsing failed, did you mean '\"%s\"'?", OneWord(ctx));
     } else {
         Macros_ReportErrorTok(ctx, "Could not parse");
     }
     return noneVar();
+#endif
 }
 
 static macro_variable_t negate(parser_context_t *ctx, macro_variable_t res)

--- a/right/src/macros/vars.c
+++ b/right/src/macros/vars.c
@@ -1186,8 +1186,18 @@ static macro_variable_t consumeArgumentAsValue(parser_context_t* ctx) {
         // for type 'any', consume the value as a template expansion (i.e. like &macroArg)
         // for compatibility with existing macros that don't declare their argument types.
 
-        PushParserContext(ctx, str.start, str.start, str.end);
-        return consumeValue(ctx);
+        // PushParserContext(ctx, str.start, str.start, str.end);
+        // return consumeValue(ctx);
+        parser_context_t varCtx = (parser_context_t) {
+            .at = str.start,
+            .begin = str.start,
+            .end = str.end,
+            .macroState = ctx->macroState,
+            .nestingLevel = ctx->nestingLevel,
+            .nestingBound = ctx->nestingBound,
+        };
+
+        return consumeValue(&varCtx);
     } else {
             // for declared types, consume the value according to type.
             parser_context_t varCtx = (parser_context_t) {

--- a/right/src/macros/vars.c
+++ b/right/src/macros/vars.c
@@ -185,10 +185,10 @@ static macro_variable_t consumeKeyIdValue(parser_context_t* ctx)
 static macro_variable_t consumeScancodeValue(parser_context_t* ctx)
 // consume "scancode" = modded scancode = "shortcut", return as string variable.
 {
+    // this function could preparse the Mods+Scancode for validity, e.g.
+    //   macro_action_t action = decodeKeyAndConsume(ctx, MacroSubAction_None);
+    // but for now we return the raw string.
     const char* atStart = ctx->at;
-    // should preparse the Mods+Scancode for validity.
-    // macro_action_t action = decodeKeyAndConsume(ctx, MacroSubAction_None);
-    // const char* atEnd = ctx->at;
     const char* atEnd = TokEnd(ctx->at, ctx->end);
     ConsumeWhiteAt(ctx, atEnd);
 

--- a/right/src/macros/vars.c
+++ b/right/src/macros/vars.c
@@ -505,7 +505,7 @@ static macro_variable_t consumeValue(parser_context_t* ctx)
         default:
             goto failed;
     }
-a   a   
+
 failed:
     if (IsIdentifierChar(*ctx->at)) {
         Macros_ReportErrorPrintf(ctx->at, "Parsing failed, did you mean '\"%s\"'?", OneWord(ctx));

--- a/right/src/macros/vars.c
+++ b/right/src/macros/vars.c
@@ -59,6 +59,10 @@ static macro_variable_t consumeValue(parser_context_t* ctx);
 static macro_variable_t negate(parser_context_t *ctx, macro_variable_t res);
 static macro_variable_t consumeMinMaxOperation(parser_context_t* ctx, operator_t op);
 static macro_variable_t negateBool(parser_context_t *ctx, macro_variable_t res);
+static macro_variable_t coalesceType(parser_context_t* ctx, macro_variable_t value, macro_variable_type_t dstType);
+
+static string_ref_t createStringRef(const char *start, const char *end);
+static string_segment_t stringRefToSegment(string_ref_t ref);
 
 macro_result_t Macros_ProcessStatsVariablesCommand(void) {
     if (Macros_DryRun) {
@@ -80,10 +84,10 @@ static macro_variable_t intVar(int32_t value)
     return (macro_variable_t) { .asInt = value, .type = MacroVariableType_Int };
 }
 
-static macro_variable_t floatVar(float value)
-{
-    return (macro_variable_t) { .asFloat = value, .type = MacroVariableType_Float };
-}
+//static macro_variable_t floatVar(float value)
+//{
+//    return (macro_variable_t) { .asFloat = value, .type = MacroVariableType_Float };
+//}
 
 static macro_variable_t boolVar(bool value)
 {

--- a/right/src/macros/vars.c
+++ b/right/src/macros/vars.c
@@ -1186,8 +1186,9 @@ static macro_variable_t consumeArgumentAsValue(parser_context_t* ctx) {
         // for type 'any', consume the value as a template expansion (i.e. like &macroArg)
         // for compatibility with existing macros that don't declare their argument types.
 
-        // PushParserContext(ctx, str.start, str.start, str.end);
-        // return consumeValue(ctx);
+        PushParserContext(ctx, str.start, str.start, str.end);
+        return consumeValue(ctx);
+#if 0
         parser_context_t varCtx = (parser_context_t) {
             .at = str.start,
             .begin = str.start,
@@ -1198,6 +1199,7 @@ static macro_variable_t consumeArgumentAsValue(parser_context_t* ctx) {
         };
 
         return consumeValue(&varCtx);
+#endif
     } else {
             // for declared types, consume the value according to type.
             parser_context_t varCtx = (parser_context_t) {

--- a/right/src/macros/vars.c
+++ b/right/src/macros/vars.c
@@ -1259,18 +1259,24 @@ static bool expandArgumentInplace(parser_context_t* ctx, uint8_t argNumber) {
 bool TryExpandMacroTemplateOnce(parser_context_t* ctx) {
     ASSERT(*ctx->at == '&');
 
+    // save context position to restore if the "try" fails
+    const char *savedAt = ctx->at;
+
     ctx->at++;
 
     Trace_Printc("e1");
 
     if (ConsumeToken(ctx, "macroArg")) {
-        ConsumeOneDot(ctx);
-        uint8_t argId = Macros_ConsumeInt(ctx);
-        expandArgumentInplace(ctx, argId);
-        return true;
+        if(ConsumeOneDot(ctx)) {
+            uint8_t argId = Macros_ConsumeInt(ctx);
+            expandArgumentInplace(ctx, argId);
+            return true;
+        }
     }
 
-    ctx->at--;
+    // restore parser context if no expansion was performed
+    ctx->at = savedAt;
+
     return false;
 }
 

--- a/right/src/macros/vars.c
+++ b/right/src/macros/vars.c
@@ -1056,10 +1056,8 @@ static macro_variable_t consumeArgumentAsValue(parser_context_t* ctx) {
             return noneVar();
         }
 
-        // TODO: parse macro argument name and convert to number.
-        //       basically, Macros_FindMacroArgumentByName(), error if not found.
-        //       if found, consume the name and retrieve argument number and argument type.
-
+        // parse macro argument name and convert to number; error if not found.
+        // if found, consume the name and retrieve argument number and argument type.
         macro_argument_t *arg = Macros_FindMacroArgumentByName(MACRO_STATE_SLOT(S), idStart, idEnd);
         if (arg == NULL) {
             Macros_ReportErrorPrintf(ctx->at, "Argument with name '$macroArg.%s' not found!", OneWord(ctx));
@@ -1070,14 +1068,13 @@ static macro_variable_t consumeArgumentAsValue(parser_context_t* ctx) {
         ConsumeWhiteAt(ctx, idEnd);
     } else {
         // argument accessed by number, e.g., $macroArg.1
+
         argIdx = Macros_ConsumeInt(ctx);
         macro_argument_t *arg = Macros_FindMacroArgumentByIndex(MACRO_STATE_SLOT(S), argIdx);
         if (arg == NULL) {
+            // if not found (= undeclared), assume type 'any' for this argument
+            // (backwards compatibility to macro arguments without macroArg declaration).
             argType = MacroArgType_Any;
-            // TODO: assume type 'any' for this argument; 
-            //       it has probably not been declared in any macroArg statement.
-            Macros_ReportErrorPrintf(ctx->at, "Argument with id %d not found!", argIdx);
-            return noneVar();
         } else {
             argType = arg->type;
         }
@@ -1096,17 +1093,6 @@ static macro_variable_t consumeArgumentAsValue(parser_context_t* ctx) {
         return noneVar();
     }
 
-    // TODO: if argument type is known, parse value accordingly.
-    //       if type == any, then expand??
-
-//    if (argType == MacroArgType_Any) {
-//        Trace_Printc("Argument type is any, trying to parse as template.");
-//        PushParserContext(ctx, str.start, str.start, str.end);
-//        if (Macros_ParserError) {
-//            return noneVar();
-//        }
-//    }
-
     parser_context_t varCtx = (parser_context_t) {
         .at = str.start,
         .begin = str.start,
@@ -1116,9 +1102,6 @@ static macro_variable_t consumeArgumentAsValue(parser_context_t* ctx) {
         .nestingBound = ctx->nestingBound,
     };
 
-//  old code:  macro_variable_t res = consumeValue(&varCtx);
-
-//  new code:
     if (argType == MacroArgType_Any) {
         // for type 'any', consume the value the "old way"
         // (compatibility with existing macros that don't declare their argument types).
@@ -1127,9 +1110,9 @@ static macro_variable_t consumeArgumentAsValue(parser_context_t* ctx) {
         // for declared types, consume the value according to type.
         switch (argType) {
             case MacroArgType_Int:
-                return consumeNumericValue(&varCtx); // should be: consumeIntValue()
+                return consumeNumericValue(&varCtx); // TODO: should be: consumeIntValue()
             case MacroArgType_Float:
-                return consumeNumericValue(&varCtx); // should be: consumeFloatValue()
+                return consumeNumericValue(&varCtx); // TODO: should be: consumeFloatValue()
             case MacroArgType_Bool:
                 return consumeBool(&varCtx);
             case MacroArgType_String: {

--- a/right/src/macros/vars.c
+++ b/right/src/macros/vars.c
@@ -107,7 +107,7 @@ static macro_variable_t consumeNumericValueOfType(parser_context_t* ctx, macro_n
     }
     if (*ctx->at == '.') {
         if (expectedType == MacroNumericalValueType_Int) {
-            Macros_ReportErrorTok(ctx, "Integer value expected");
+            Macros_ReportErrorTok(ctx, "Integer value expected but found:");
             return noneVar();
         }
         res.type = MacroVariableType_Float;
@@ -123,7 +123,7 @@ static macro_variable_t consumeNumericValueOfType(parser_context_t* ctx, macro_n
         }
     }
     if (!numFound) {
-        Macros_ReportErrorTok(ctx, "Numeric value expected");
+        Macros_ReportErrorTok(ctx, "Numeric value expected but found:");
         return noneVar();
     }
 
@@ -160,7 +160,7 @@ static macro_variable_t consumeBool(parser_context_t* ctx)
         return (macro_variable_t){ .type = MacroVariableType_Bool, .asBool = true };
     }
 
-    Macros_ReportErrorTok(ctx, "Boolean value (true/false) expected");
+    Macros_ReportErrorTok(ctx, "Boolean value (true/false) expected but found:");
     return noneVar();
 }
 
@@ -430,6 +430,7 @@ static macro_variable_t consumeDollarExpression(parser_context_t* ctx)
 
 static macro_variable_t consumeValue(parser_context_t* ctx)
 {
+    // TODO: this shouldn't be here, when properly handled by $macroArg :any type.
     if (*ctx->at == '&') {
         TryExpandMacroTemplateOnce(ctx);
         if (Macros_ParserError) {

--- a/right/src/macros/vars.c
+++ b/right/src/macros/vars.c
@@ -95,7 +95,7 @@ static macro_variable_t noneVar()
     return (macro_variable_t) { .asInt = 1, .type = MacroVariableType_None };
 }
 
-static macro_variable_t consumeNumericValue(parser_context_t* ctx)
+static macro_variable_t consumeNumericValueOfType(parser_context_t* ctx, macro_numericalvalue_type_t expectedType)
 {
     macro_variable_t res = { .type = MacroVariableType_Int, .asInt = 0 };
 
@@ -106,6 +106,10 @@ static macro_variable_t consumeNumericValue(parser_context_t* ctx)
         numFound = true;
     }
     if (*ctx->at == '.') {
+        if (expectedType == MacroNumericalValueType_Int) {
+            Macros_ReportErrorTok(ctx, "Integer value expected");
+            return noneVar();
+        }
         res.type = MacroVariableType_Float;
         res.asFloat = (float) res.asInt;
         ctx->at++;
@@ -123,8 +127,28 @@ static macro_variable_t consumeNumericValue(parser_context_t* ctx)
         return noneVar();
     }
 
+    if (expectedType == MacroNumericalValueType_Float && res.type == MacroVariableType_Int) {
+        res.asFloat = (float) res.asInt;
+        res.type = MacroVariableType_Float;
+    }
+
     ConsumeWhite(ctx);
     return res;
+}
+
+static macro_variable_t consumeIntValue(parser_context_t* ctx)
+{
+    return consumeNumericValueOfType(ctx, MacroNumericalValueType_Int;
+}
+
+static macro_variable_t consumeFloatValue(parser_context_t* ctx)
+{
+    return consumeNumericValueOfType(ctx, MacroNumericalValueType_Float);
+}
+
+static macro_variable_t consumeNumericValue(parser_context_t* ctx)
+{
+    return consumeNumericValueOfType(ctx, MacroNumericalValueType_Any);
 }
 
 static macro_variable_t consumeBool(parser_context_t* ctx)
@@ -1110,9 +1134,9 @@ static macro_variable_t consumeArgumentAsValue(parser_context_t* ctx) {
         // for declared types, consume the value according to type.
         switch (argType) {
             case MacroArgType_Int:
-                return consumeNumericValue(&varCtx); // TODO: should be: consumeIntValue()
+                return consumeIntValue(&varCtx);
             case MacroArgType_Float:
-                return consumeNumericValue(&varCtx); // TODO: should be: consumeFloatValue()
+                return consumeFloatValue(&varCtx);
             case MacroArgType_Bool:
                 return consumeBool(&varCtx);
             case MacroArgType_String: {

--- a/right/src/macros/vars.c
+++ b/right/src/macros/vars.c
@@ -1109,6 +1109,7 @@ static macro_variable_t consumeArgumentAsValue(parser_context_t* ctx) {
 
     if (S->ms.currentMacroArgumentOffset == 0) {
         Macros_ReportErrorPrintf(ctx->at, "Failed to retrieve argument %d, because this macro doesn't seem to have arguments assigned!", argIdx);
+        return noneVar();
     }
 
     string_segment_t str = ParseMacroArgument(S->ms.currentMacroArgumentOffset, argIdx);
@@ -1118,27 +1119,27 @@ static macro_variable_t consumeArgumentAsValue(parser_context_t* ctx) {
         return noneVar();
     }
 
-    parser_context_t varCtx = (parser_context_t) {
-        .at = str.start,
-        .begin = str.start,
-        .end = str.end,
-        .macroState = ctx->macroState,
-        .nestingLevel = ctx->nestingLevel,
-        .nestingBound = ctx->nestingBound,
-    };
-
     if (argType == MacroArgType_Any) {
-        // for type 'any', consume the value the "old way"
-        // (compatibility with existing macros that don't declare their argument types).
-        // but that doesn't work well ($macroArg vs. &macroArg).
+        // for type 'any', consume the value as a template expansion (i.e. &macroArg)
+        // for compatibility with existing macros that don't declare their argument types.
 
-        // TODO: really, we should probably handle template expansion here (treat it as &macroArg).
-        //       Currently, it fails when unquoted strings are supplied as argument value, and
-        //       it fails with a very weird error message.
-        return consumeValue(&varCtx);   // this has limited functionality
+        PushParserContext(ctx, str.start, str.start, str.end);
+        //if (Macros_ParserError) {
+        //    return noneVar();
+       // }
+        return consumeValue(ctx);
     } else {
-        // for declared types, consume the value according to type.
-        switch (argType) {
+            // for declared types, consume the value according to type.
+            parser_context_t varCtx = (parser_context_t) {
+                .at = str.start,
+                .begin = str.start,
+                .end = str.end,
+                .macroState = ctx->macroState,
+                .nestingLevel = ctx->nestingLevel,
+                .nestingBound = ctx->nestingBound,
+            };
+        
+            switch (argType) {
             case MacroArgType_Int:
                 return consumeIntValue(&varCtx);
             case MacroArgType_Float:

--- a/right/src/macros/vars.c
+++ b/right/src/macros/vars.c
@@ -1220,6 +1220,10 @@ static string_segment_t stringRefToSegment(string_ref_t ref) {
     };
 }
 
+string_segment_t StringRefToSegment(string_ref_t ref) {
+    return stringRefToSegment(ref);
+}
+
 // currently unused:
 //static const char *stringRefStart(string_ref_t ref) {
 //    return (const char *)(ValidatedUserConfigBuffer.buffer + ref.offset);

--- a/right/src/macros/vars.c
+++ b/right/src/macros/vars.c
@@ -164,6 +164,16 @@ static macro_variable_t consumeBool(parser_context_t* ctx)
     return noneVar();
 }
 
+static macro_variable_t consumeRawStringNonExpanded(parser_context_t* ctx)
+{
+    // the remaining context is the string. No expansions.
+    uint16_t offset = ctx->at - (const char*)ValidatedUserConfigBuffer.buffer;
+    uint8_t len = ctx->end - ctx->at;
+    ctx->at = ctx->end;
+
+    return stringVar((string_ref_t){ .offset = offset, .len = len });
+}
+
 static macro_variable_t consumeStringLiteral(parser_context_t* ctx)
 {
     const char* stringStart = ctx->at;
@@ -471,7 +481,6 @@ static macro_variable_t consumeValue(parser_context_t* ctx)
             else {
                 goto failed;
             }
-
         case 't':
             if (ConsumeToken(ctx, "true")) {
                 return (macro_variable_t){ .type = MacroVariableType_Bool, .asBool = true };
@@ -479,7 +488,6 @@ static macro_variable_t consumeValue(parser_context_t* ctx)
             else {
                 goto failed;
             }
-
         case '$':
             ctx->at++;
             return consumeDollarExpression(ctx);
@@ -497,10 +505,10 @@ static macro_variable_t consumeValue(parser_context_t* ctx)
         default:
             goto failed;
     }
-
+a   a   
 failed:
     if (IsIdentifierChar(*ctx->at)) {
-        Macros_ReportErrorPrintf(ctx->at, "Parsing failed, did you mean '$%s'?", OneWord(ctx));
+        Macros_ReportErrorPrintf(ctx->at, "Parsing failed, did you mean '\"%s\"'?", OneWord(ctx));
     } else {
         Macros_ReportErrorTok(ctx, "Could not parse");
     }
@@ -1120,13 +1128,10 @@ static macro_variable_t consumeArgumentAsValue(parser_context_t* ctx) {
     }
 
     if (argType == MacroArgType_Any) {
-        // for type 'any', consume the value as a template expansion (i.e. &macroArg)
+        // for type 'any', consume the value as a template expansion (i.e. like &macroArg)
         // for compatibility with existing macros that don't declare their argument types.
 
         PushParserContext(ctx, str.start, str.start, str.end);
-        //if (Macros_ParserError) {
-        //    return noneVar();
-       // }
         return consumeValue(ctx);
     } else {
             // for declared types, consume the value according to type.
@@ -1147,7 +1152,12 @@ static macro_variable_t consumeArgumentAsValue(parser_context_t* ctx) {
             case MacroArgType_Bool:
                 return consumeBool(&varCtx);
             case MacroArgType_String: {
-                return consumeStringLiteral(&varCtx);
+                // this used to be consumeStringLiteral, but that leads to $-expansions
+                // within the string, even if not enclosed in double-quotes. 
+                // Values configured for arguments should be interpreted as raw strings 
+                // without expansions.
+                // Use type 'any' if you want $-expansions in your arguments.
+                return consumeRawStringNonExpanded(&varCtx);
             }
             default:
                 Macros_ReportErrorNum("Unexpected argument type:", argType, NULL);

--- a/right/src/macros/vars.c
+++ b/right/src/macros/vars.c
@@ -1132,7 +1132,9 @@ static macro_variable_t consumeArgumentAsValue(parser_context_t* ctx) {
         // (compatibility with existing macros that don't declare their argument types).
         // but that doesn't work well ($macroArg vs. &macroArg).
 
-        // TODO: really, we should probably handle template expansion here (treat is as &macroArg).
+        // TODO: really, we should probably handle template expansion here (treat it as &macroArg).
+        //       Currently, it fails when unquoted strings are supplied as argument value, and
+        //       it fails with a very weird error message.
         return consumeValue(&varCtx);   // this has limited functionality
     } else {
         // for declared types, consume the value according to type.

--- a/right/src/macros/vars.c
+++ b/right/src/macros/vars.c
@@ -259,7 +259,7 @@ static macro_variable_t consumeVariable(parser_context_t* ctx)
     }
 
     ConsumeAnyIdentifier(ctx);
-    return (macro_variable_t){};
+    return (macro_variable_t){};    // TODO: shouldn't this be noneVar()?
 }
 
 // Expects <variable name>
@@ -424,7 +424,7 @@ static macro_variable_t consumeDollarExpression(parser_context_t* ctx)
         return intVar(Timer_GetCurrentTime() & 0x7FFFFFFF);
     }
     else if (ConsumeToken(ctx, "queuedKeyId")) {
-        ConsumeUntilDot(ctx);
+        ConsumeOneDot(ctx);
         int8_t queueIdx = Macros_ConsumeInt(ctx);
         if (queueIdx >= PostponerQuery_PendingKeypressCount()) {
             if (!Macros_DryRun) {
@@ -436,7 +436,7 @@ static macro_variable_t consumeDollarExpression(parser_context_t* ctx)
         return intVar(PostponerExtended_PendingId(queueIdx));
     }
     else if (ConsumeToken(ctx, "keyId")) {
-        ConsumeUntilDot(ctx);
+        ConsumeOneDot(ctx);
         uint8_t keyId = MacroKeyIdParser_TryConsumeKeyId(ctx);
         if (keyId == 255) {
             Macros_ReportErrorTok(ctx, "KeyId abbreviation expected:");
@@ -445,7 +445,7 @@ static macro_variable_t consumeDollarExpression(parser_context_t* ctx)
         return intVar(keyId);
     }
     else if (ConsumeToken(ctx, "uhk")) {
-        ConsumeUntilDot(ctx);
+        ConsumeOneDot(ctx);
         if (ConsumeToken(ctx, "name")) {
             return stringVar(Cfg.DeviceName);
         } else {
@@ -1264,7 +1264,7 @@ bool TryExpandMacroTemplateOnce(parser_context_t* ctx) {
     Trace_Printc("e1");
 
     if (ConsumeToken(ctx, "macroArg")) {
-        ConsumeUntilDot(ctx);
+        ConsumeOneDot(ctx);
         uint8_t argId = Macros_ConsumeInt(ctx);
         expandArgumentInplace(ctx, argId);
         return true;

--- a/right/src/macros/vars.c
+++ b/right/src/macros/vars.c
@@ -1129,7 +1129,10 @@ static macro_variable_t consumeArgumentAsValue(parser_context_t* ctx) {
     if (argType == MacroArgType_Any) {
         // for type 'any', consume the value the "old way"
         // (compatibility with existing macros that don't declare their argument types).
-        return consumeValue(&varCtx);
+        // but that doesn't work well ($macroArg vs. &macroArg).
+
+        // TODO: really, we should probably handle template expansion here (treat is as &macroArg).
+        return consumeValue(&varCtx);   // this has limited functionality
     } else {
         // for declared types, consume the value according to type.
         switch (argType) {

--- a/right/src/macros/vars.c
+++ b/right/src/macros/vars.c
@@ -1186,9 +1186,12 @@ static macro_variable_t consumeArgumentAsValue(parser_context_t* ctx) {
         // for type 'any', consume the value as a template expansion (i.e. like &macroArg)
         // for compatibility with existing macros that don't declare their argument types.
 
+#if 0
+        // TODO: This doesn't work; it will cause firmware crashes.
+        // I don't understand why.
         PushParserContext(ctx, str.start, str.start, str.end);
         return consumeValue(ctx);
-#if 0
+#else
         parser_context_t varCtx = (parser_context_t) {
             .at = str.start,
             .begin = str.start,

--- a/right/src/macros/vars.c
+++ b/right/src/macros/vars.c
@@ -138,7 +138,7 @@ static macro_variable_t consumeNumericValueOfType(parser_context_t* ctx, macro_n
 
 static macro_variable_t consumeIntValue(parser_context_t* ctx)
 {
-    return consumeNumericValueOfType(ctx, MacroNumericalValueType_Int;
+    return consumeNumericValueOfType(ctx, MacroNumericalValueType_Int);
 }
 
 static macro_variable_t consumeFloatValue(parser_context_t* ctx)
@@ -1203,13 +1203,15 @@ static string_segment_t stringRefToSegment(string_ref_t ref) {
     };
 }
 
-static const char *stringRefStart(string_ref_t ref) {
-    return (const char *)(ValidatedUserConfigBuffer.buffer + ref.offset);
-}
+// currently unused:
+//static const char *stringRefStart(string_ref_t ref) {
+//    return (const char *)(ValidatedUserConfigBuffer.buffer + ref.offset);
+//}
 
-static const char *stringRefEnd(string_ref_t ref) {
-    return (const char *)(ValidatedUserConfigBuffer.buffer + ref.offset + ref.len);
-}
+// currently unused:
+//static const char *stringRefEnd(string_ref_t ref) {
+//    return (const char *)(ValidatedUserConfigBuffer.buffer + ref.offset + ref.len);
+//}
 
 // Allocates a macro argument in the pool and returns a reference to it. 
 // Fails if an argument with the same name already exists for this owner, 

--- a/right/src/macros/vars.h
+++ b/right/src/macros/vars.h
@@ -56,7 +56,8 @@
         macro_argument_type_t type;
         uint8_t idx;            // index of the argument in the macro's argument list (1-based)
                                 // (we could always calculate idx by looping through the pool, 
-                                //  but returning argument+index separately everywhere becomes a nightmare...)
+                                //  but returning argument+index separately everywhere becomes 
+                                //  a nightmare...)
         string_ref_t name;      // macro argument name (identifier)
     } macro_argument_t;
 

--- a/right/src/macros/vars.h
+++ b/right/src/macros/vars.h
@@ -59,12 +59,12 @@
 
     typedef struct {
         uint8_t owner;          // MACRO_STATE_SLOT() of the macro that owns this argument
-        macro_argument_type_t type;
         uint8_t idx;            // index of the argument in the macro's argument list (1-based)
                                 // (we could always calculate idx by looping through the pool, 
                                 //  but returning argument+index separately everywhere becomes 
                                 //  a nightmare...)
         string_ref_t name;      // macro argument name (identifier)
+        macro_argument_type_t type;
     } macro_argument_t;
 
     typedef enum {

--- a/right/src/macros/vars.h
+++ b/right/src/macros/vars.h
@@ -84,6 +84,7 @@
     int32_t Macros_ConsumeInt(parser_context_t* ctx);
     float Macros_ConsumeFloat(parser_context_t* ctx);
     bool Macros_ConsumeBool(parser_context_t* ctx);
+    string_segment_t Macros_ConsumeString(parser_context_t* ctx);
     macro_variable_t Macros_ConsumeAnyValue(parser_context_t* ctx);
     void MacroVariables_RunTests(void);
     void Macros_SerializeVar(char* buffer, uint8_t len, macro_variable_t var);

--- a/right/src/macros/vars.h
+++ b/right/src/macros/vars.h
@@ -90,6 +90,7 @@
     void Macros_SerializeVar(char* buffer, uint8_t len, macro_variable_t var);
     bool TryExpandMacroTemplateOnce(parser_context_t* ctx);
 
+    string_segment_t StringRefToSegment(string_ref_t ref);
     macro_argument_alloc_result_t Macros_AllocateMacroArgument(uint8_t owner, const char *idStart, const char *idEnd, macro_argument_type_t type, uint8_t argNumber);
     void Macros_DeallocateMacroArgumentsByOwner(uint8_t owner);
     uint8_t Macros_CountMacroArgumentsByOwner(uint8_t owner);

--- a/right/src/macros/vars.h
+++ b/right/src/macros/vars.h
@@ -22,6 +22,12 @@
 // Typedefs:
 
     typedef enum {
+        MacroNumericalValueType_Any = 0,
+        MacroNumericalValueType_Int,
+        MacroNumericalValueType_Float,
+    } macro_numericalvalue_type_t;
+
+    typedef enum {
         MacroVariableType_Int,
         MacroVariableType_Float,
         MacroVariableType_Bool,

--- a/right/src/macros/vars.h
+++ b/right/src/macros/vars.h
@@ -28,11 +28,11 @@
     } macro_numericalvalue_type_t;
 
     typedef enum {
+        MacroVariableType_None = 0,
         MacroVariableType_Int,
         MacroVariableType_Float,
         MacroVariableType_Bool,
         MacroVariableType_String,
-        MacroVariableType_None,
     } macro_variable_type_t;
 
     typedef struct {

--- a/right/src/segment_display.c
+++ b/right/src/segment_display.c
@@ -125,7 +125,7 @@ void SegmentDisplay_SerializeVar(char* buffer, macro_variable_t var)
             SegmentDisplay_SerializeInt(buffer, var.asBool);
             break;
         case MacroVariableType_String:
-            SegmentDisplay_SerializeString(buffer, var.asStringRef)
+            SegmentDisplay_SerializeString(buffer, var.asStringRef);
             break;
         default:
             Macros_ReportErrorNum("Unexpected variable type:", var.type, NULL);
@@ -136,15 +136,17 @@ void SegmentDisplay_SerializeVar(char* buffer, macro_variable_t var)
 void SegmentDisplay_SerializeString(char* buffer, string_ref_t strRef)
 {
     RETURN_IF_SEGMENT_NOT_PRESENT;
+    string_segment_t strSeg = StringRefToSegment(strRef);
+
     // copy the first 3 chars of the string, pad with spaces if shorter.
     for (uint8_t i = 0; i < 3; i++) {
         if (i < strRef.len) {
-            buffer[i] = ((char*)ValidatedUserConfigBuffer.buffer)[strRef.offset + i];
+            buffer[i] = strSeg.start[i];
         } else {
             buffer[i] = ' ';
         }
     }
-} 
+}
 
 void SegmentDisplay_SerializeFloat(char* buffer, float num)
 {

--- a/right/src/segment_display.c
+++ b/right/src/segment_display.c
@@ -124,11 +124,27 @@ void SegmentDisplay_SerializeVar(char* buffer, macro_variable_t var)
         case MacroVariableType_Bool:
             SegmentDisplay_SerializeInt(buffer, var.asBool);
             break;
+        case MacroVariableType_String:
+            SegmentDisplay_SerializeString(buffer, var.asStringRef)
+            break;
         default:
             Macros_ReportErrorNum("Unexpected variable type:", var.type, NULL);
             break;
     }
 }
+
+void SegmentDisplay_SerializeString(char* buffer, string_ref_t strRef)
+{
+    RETURN_IF_SEGMENT_NOT_PRESENT;
+    // copy the first 3 chars of the string, pad with spaces if shorter.
+    for (uint8_t i = 0; i < 3; i++) {
+        if (i < strRef.len) {
+            buffer[i] = ((char*)ValidatedUserConfigBuffer.buffer)[strRef.offset + i];
+        } else {
+            buffer[i] = ' ';
+        }
+    }
+} 
 
 void SegmentDisplay_SerializeFloat(char* buffer, float num)
 {

--- a/right/src/segment_display.h
+++ b/right/src/segment_display.h
@@ -34,6 +34,7 @@
     void SegmentDisplay_SetText(uint8_t len, const char* text, segment_display_slot_t slot);
     void SegmentDisplay_SetInt(int32_t a, segment_display_slot_t slot);
     void SegmentDisplay_SetFloat(float a, segment_display_slot_t slot);
+    void SegmentDisplay_SerializeString(char* buffer, string_ref_t strRef);
     void SegmentDisplay_SerializeInt(char* buffer, int32_t a);
     void SegmentDisplay_SerializeFloat(char* buffer, float f);
     void SegmentDisplay_SerializeVar(char* buffer, macro_variable_t var);

--- a/right/src/str_utils.c
+++ b/right/src/str_utils.c
@@ -349,6 +349,7 @@ void ConsumeAnyIdentifier(parser_context_t* ctx)
     consumeWhite(ctx);
 }
 
+#if 0
 // Consume characters until a specific character is found or whitespace is hit.
 // If end of context is reached, report an error.
 // If the character is found, consume it.
@@ -376,7 +377,9 @@ void ConsumeUntilDot(parser_context_t* ctx)
 {
     ConsumeUntilCharOrWhite(ctx, '.', true);
 }
+#endif
 
+// will consume exactly one character.
 // will not consume whitespace after the character.
 // returns true if the character was found, false otherwise.
 bool ConsumeOneChar(parser_context_t* ctx, char c)

--- a/right/src/str_utils.c
+++ b/right/src/str_utils.c
@@ -124,7 +124,7 @@ static bool isEnd(parser_context_t* ctx) {
         return false;
     }
     while (ctx->nestingLevel > 0 && ctx->at >= ctx->end && PopParserContext(ctx)) {
-        /* everything was don in PopParserContext */
+        /* everything was done in PopParserContext */
     };
     return ctx->at >= ctx->end;
 }
@@ -439,7 +439,7 @@ bool TokenMatches2(const char *a, const char *aEnd, const char *b, const char *b
 uint8_t TokLen(const char *a, const char *aEnd)
 {
     uint8_t l = 0;
-    while(*a > 32 && a < aEnd) {
+    while(a < aEnd && *a > 32) {
         l++;
         a++;
     }
@@ -448,7 +448,7 @@ uint8_t TokLen(const char *a, const char *aEnd)
 
 const char* TokEnd(const char* cmd, const char *cmdEnd)
 {
-    while(*cmd > 32 && cmd < cmdEnd)    {
+    while(cmd < cmdEnd && *cmd > 32)    {
         cmd++;
     }
     return cmd;
@@ -457,10 +457,10 @@ const char* TokEnd(const char* cmd, const char *cmdEnd)
 // This doesn't handle expansions. Don't use it in actual macro context.
 const char* NextTok(const char* cmd, const char *cmdEnd)
 {
-    while(*cmd > 32 && cmd < cmdEnd)    {
+    while(cmd < cmdEnd && *cmd > 32)    {
         cmd++;
     }
-    while(*cmd <= 32 && cmd < cmdEnd) {
+    while(cmd < cmdEnd && *cmd <= 32) {
         cmd++;
     }
     if (cmd < cmdEnd - 1 && cmd[0] == '/' && cmd[1] == '/') {
@@ -471,7 +471,7 @@ const char* NextTok(const char* cmd, const char *cmdEnd)
 
 void ConsumeAnyToken(parser_context_t* ctx)
 {
-    while (*ctx->at > 32 && ctx->at < ctx->end) {
+    while (ctx->at < ctx->end && *ctx->at > 32) {
         ctx->at++;
     }
     consumeWhite(ctx);
@@ -482,12 +482,12 @@ struct command_entry* ConsumeGperfToken(parser_context_t* ctx)
     const char* start = ctx->at;
 
     // parse an identifier token
-    while (isIdentifierChar(*ctx->at) && ctx->at < ctx->end) {
+    while (ctx->at < ctx->end && isIdentifierChar(*ctx->at)) {
         ctx->at++;
     }
 
     // parse a single char operator if token wasn't matched.
-    if (ctx->at == start && !isIdentifierChar(*ctx->at) && *ctx->at > 32 && ctx->at < ctx->end) {
+    if (ctx->at < ctx->end && ctx->at == start && !isIdentifierChar(*ctx->at) && *ctx->at > 32) {
         ctx->at++;
     }
 
@@ -498,11 +498,11 @@ struct command_entry* ConsumeGperfToken(parser_context_t* ctx)
 
 const char* NextCmd(const char* cmd, const char *cmdEnd)
 {
-    while(*cmd != '\n' && cmd < cmdEnd)    {
+    while(cmd < cmdEnd && *cmd != '\n')    {
         cmd++;
     }
     const char* lastNewline = cmd;
-    while(*cmd <= 32 && cmd < cmdEnd) {
+    while(cmd < cmdEnd && *cmd <= 32) {
         if (*cmd == '\n') {
             lastNewline = cmd;
         }
@@ -518,7 +518,7 @@ const char* NextCmd(const char* cmd, const char *cmdEnd)
 
 const char* CmdEnd(const char* cmd, const char *cmdEnd)
 {
-    while(*cmd != '\n' && cmd < cmdEnd)    {
+    while(cmd < cmdEnd && *cmd != '\n')    {
         cmd++;
     }
     return cmd;
@@ -526,7 +526,7 @@ const char* CmdEnd(const char* cmd, const char *cmdEnd)
 
 const char* SkipWhite(const char* cmd, const char *cmdEnd)
 {
-    while(*cmd <= 32 && cmd < cmdEnd) {
+    while(cmd < cmdEnd && *cmd <= 32) {
         cmd++;
     }
     return cmd;
@@ -681,7 +681,7 @@ uint8_t CountCommands(const char* text, uint16_t textLen)
     uint8_t count = 1;
     const char* textEnd = text + textLen;
 
-    while ( *text <= 32 && text < textEnd) {
+    while (text < textEnd && *text <= 32) {
         text++;
     }
 
@@ -769,4 +769,3 @@ const char* DeviceModelName(device_id_t device) {
             return "Unknown device";
     }
 }
-

--- a/right/src/str_utils.c
+++ b/right/src/str_utils.c
@@ -170,6 +170,9 @@ static void consumeWhite(parser_context_t* ctx)
                 ctx->at++;
             }
         }
+        // TODO: this TRY_EXPAND_TEMPLATE needs to be replaced with expansion of $macroArg:any here.
+        //       Note: possible command injection vulnerability if we allow template expansion in white space.
+        //       Do we want to allow this at all?
         if (TRY_EXPAND_TEMPLATE(ctx)) {
             continue;
         } else {

--- a/right/src/str_utils.c
+++ b/right/src/str_utils.c
@@ -162,11 +162,11 @@ bool IsWhite(parser_context_t* ctx) {
 static void consumeWhite(parser_context_t* ctx)
 {
     while (!isEnd(ctx)) {
-        while (*ctx->at <= 32 && !isEnd(ctx)) {
+        while (!isEnd(ctx) && ctx->at <= 32) {
             ctx->at++;
         }
-        if (isCommentLeader(ctx) && consumeCommentsAsWhite) {
-            while (*ctx->at != '\n' && !isEnd(ctx)) {
+        if (consumeCommentsAsWhite && isCommentLeader(ctx)) {
+            while (!isEnd(ctx) && *ctx->at != '\n') {
                 ctx->at++;
             }
         }
@@ -236,8 +236,8 @@ bool ConsumeToken(parser_context_t* ctx, const char *b)
 {
     const char* at = ctx->at;
     while(at < ctx->end && *b) {
-        if (*at <= 32 || at == ctx->end || *b <= 32) {
-            bool res = (*at <= 32 || at == ctx->end) && *b <= 32;
+        if (at >= ctx->end || *at <= 32 || *b <= 32) {
+            bool res = (at >= ctx->end || *at <= 32) && *b <= 32;
             if (res) {
                 ctx->at = at;
                 consumeWhite(ctx);
@@ -248,7 +248,7 @@ bool ConsumeToken(parser_context_t* ctx, const char *b)
             return false;
         }
     }
-    bool res = (*at <= 32 || at == ctx->end || !isIdentifierChar(*at) || !isIdentifierChar(*(at-1))) && *b <= 32;
+    bool res = (at >= ctx->end || *at <= 32 || !isIdentifierChar(*at) || !isIdentifierChar(*(at-1))) && *b <= 32;
     if (res) {
         ctx->at = at;
         consumeWhite(ctx);
@@ -269,8 +269,8 @@ bool ConsumeTokenByRef(parser_context_t* ctx, string_ref_t ref)
     const char* b = (const char*)(ValidatedUserConfigBuffer.buffer + ref.offset);
     const char* bEnd = (const char*)(ValidatedUserConfigBuffer.buffer + ref.offset + ref.len);
     while(at < ctx->end && b < bEnd) {
-        if (*at <= 32 || at == ctx->end || *b <= 32 || b == bEnd) {
-            bool res = (*at <= 32 || at == ctx->end) && *b <= 32;
+        if (at >= ctx->end || *at <= 32 || b >= bEnd || *b <= 32) {
+            bool res = (at >= ctx->end || *at <= 32) && *b <= 32;
             if (res) {
                 ctx->at = at;
                 consumeWhite(ctx);
@@ -281,7 +281,7 @@ bool ConsumeTokenByRef(parser_context_t* ctx, string_ref_t ref)
             return false;
         }
     }
-    bool res = (*at <= 32 || at == ctx->end || *at == '.') && (*b <= 32 || b == bEnd);
+    bool res = (at >= ctx->end || *at <= 32 || *at == '.') && (b >= bEnd || *b <= 32);
     if (res) {
         ctx->at = at;
         consumeWhite(ctx);
@@ -313,8 +313,8 @@ bool ConsumeIdentifierByRef(parser_context_t* ctx, string_ref_t ref)
     const char* b = (const char*)(ValidatedUserConfigBuffer.buffer + ref.offset);
     const char* bEnd = (const char*)(ValidatedUserConfigBuffer.buffer + ref.offset + ref.len);
     while(at < ctx->end && b < bEnd) {
-        if (!isIdentifierChar(*at) || at == ctx->end || !isIdentifierChar(*b) || b == bEnd) {
-            bool res = (!isIdentifierChar(*at) || at == ctx->end) && (!isIdentifierChar(*b) || b == bEnd);
+        if (at >= ctx->end || !isIdentifierChar(*at) || b >= bEnd || !isIdentifierChar(*b)) {
+            bool res = (at >= ctx->end || !isIdentifierChar(*at)) && (b >= bEnd || !isIdentifierChar(*b));
             if (res) {
                 ctx->at = at;
                 consumeWhite(ctx);
@@ -326,7 +326,7 @@ bool ConsumeIdentifierByRef(parser_context_t* ctx, string_ref_t ref)
         }
     }
 
-    bool res = (!isIdentifierChar(*at) || at == ctx->end) && (!isIdentifierChar(*b) || b == bEnd);
+    bool res = (at >= ctx->end || !isIdentifierChar(*at)) && (b >= bEnd || !isIdentifierChar(*b));
     if (res) {
         ctx->at = at;
         consumeWhite(ctx);
@@ -337,7 +337,7 @@ bool ConsumeIdentifierByRef(parser_context_t* ctx, string_ref_t ref)
 const char* IdentifierEnd(parser_context_t* ctx)
 {
     const char* at = ctx->at;
-    while (isIdentifierChar(*at) && at < ctx->end) {
+    while (at < ctx->end && isIdentifierChar(*at)) {
         at++;
     }
     return at;
@@ -348,21 +348,6 @@ void ConsumeAnyIdentifier(parser_context_t* ctx)
     ctx->at = IdentifierEnd(ctx);
     consumeWhite(ctx);
 }
-
-#if 0
-/* old ConsumeUntilDot (replaced below) */
-
-void ConsumeUntilDot(parser_context_t* ctx)
-{
-    while(*ctx->at > 32 && *ctx->at != '.' && !isEnd(ctx))    {
-        ctx->at++;
-    }
-    if (*ctx->at != '.') {
-        Macros_ReportError("'.' expected", ctx->at, ctx->at);
-    }
-    ctx->at++;
-}
-#endif
 
 // Consume characters until a specific character is found or whitespace is hit.
 // If end of context is reached, report an error.
@@ -413,8 +398,8 @@ bool ConsumeOneDot(parser_context_t* ctx)
 bool TokenMatches(const char *a, const char *aEnd, const char *b)
 {
     while(a < aEnd && *b) {
-        if (*a <= 32 || a == aEnd || *b <= 32) {
-            return (*a <= 32 || a == aEnd) && *b <= 32;
+        if (a >= aEnd || *a <= 32 || *b <= 32) {
+            return (a >= aEnd || *a <= 32) && *b <= 32;
         }
         if (*a++ != *b++) {
             return false;
@@ -426,14 +411,14 @@ bool TokenMatches(const char *a, const char *aEnd, const char *b)
 bool TokenMatches2(const char *a, const char *aEnd, const char *b, const char *bEnd)
 {
     while(a < aEnd && b < bEnd) {
-        if (*a <= 32 || a == aEnd || *b <= 32 || b == bEnd) {
-            return (*a <= 32 || a == aEnd) && *b <= 32;
+        if (a >= aEnd || *a <= 32 || b >= bEnd || *b <= 32) {
+            return (a >= aEnd || *a <= 32) && *b <= 32;
         }
         if (*a++ != *b++) {
             return false;
         }
     }
-    return (*a <= 32 || a == aEnd || *a == '.') && (*b <= 32 || b == bEnd);
+    return (a >= aEnd || *a <= 32 || *a == '.') && (b >= bEnd || *b <= 32);
 }
 
 uint8_t TokLen(const char *a, const char *aEnd)

--- a/right/src/str_utils.c
+++ b/right/src/str_utils.c
@@ -354,7 +354,7 @@ void ConsumeAnyIdentifier(parser_context_t* ctx)
 // If end of context is reached, report an error.
 // If the character is found, consume it.
 // If whitespace is found, and failOnWhite is true, report an error.
-void ConsumeUntilCharOrWhite(parser_context_t* ctx, char c, bool failOnWhite)
+void consumeUntilCharOrWhite(parser_context_t* ctx, char c, bool failOnWhite)
 {
     while(!isEnd(ctx) && *ctx->at > 32 && *ctx->at != c) {
         ctx->at++;
@@ -375,7 +375,7 @@ void ConsumeUntilCharOrWhite(parser_context_t* ctx, char c, bool failOnWhite)
 
 void ConsumeUntilDot(parser_context_t* ctx)
 {
-    ConsumeUntilCharOrWhite(ctx, '.', true);
+    consumeUntilCharOrWhite(ctx, '.', true);
 }
 #endif
 

--- a/right/src/str_utils.c
+++ b/right/src/str_utils.c
@@ -162,7 +162,7 @@ bool IsWhite(parser_context_t* ctx) {
 static void consumeWhite(parser_context_t* ctx)
 {
     while (!isEnd(ctx)) {
-        while (!isEnd(ctx) && ctx->at <= 32) {
+        while (!isEnd(ctx) && *ctx->at <= 32) {
             ctx->at++;
         }
         if (consumeCommentsAsWhite && isCommentLeader(ctx)) {

--- a/right/src/str_utils.h
+++ b/right/src/str_utils.h
@@ -30,7 +30,6 @@
 
 // Typedefs:
 
-
     typedef struct macro_state_t macro_state_t;
 
     typedef struct {

--- a/right/src/str_utils.h
+++ b/right/src/str_utils.h
@@ -85,7 +85,7 @@
     const char* CmdEnd(const char* cmd, const char *cmdEnd);
     bool ConsumeOneChar(parser_context_t* ctx, char c);
     bool ConsumeOneDot(parser_context_t* ctx);
-    void ConsumeUntilDot(parser_context_t* ctx);
+    void ConsumeOneDot(parser_context_t* ctx);
     void ConsumeWhiteAt(parser_context_t* ctx, const char* at);
     const char* SkipWhite(const char* cmd, const char *cmdEnd);
     uint8_t CountCommands(const char* text, uint16_t textLen);

--- a/right/src/str_utils.h
+++ b/right/src/str_utils.h
@@ -85,7 +85,7 @@
     const char* CmdEnd(const char* cmd, const char *cmdEnd);
     bool ConsumeOneChar(parser_context_t* ctx, char c);
     bool ConsumeOneDot(parser_context_t* ctx);
-    void ConsumeOneDot(parser_context_t* ctx);
+    void ConsumeUntilDot(parser_context_t* ctx);
     void ConsumeWhiteAt(parser_context_t* ctx, const char* at);
     const char* SkipWhite(const char* cmd, const char *cmdEnd);
     uint8_t CountCommands(const char* text, uint16_t textLen);


### PR DESCRIPTION
$macroArg.1 syntax now works for undeclared args (backwards compatibility); numerical value parsing is now specific for each declared type (int, float), or general number parsing for undeclared or 'any' types.